### PR TITLE
squash compiler warnings and simplification

### DIFF
--- a/source/GraphDrawing/graph.cpp
+++ b/source/GraphDrawing/graph.cpp
@@ -17,8 +17,6 @@ void Graph::deleteGraph() {
 
 bool Graph::isEmpty() const { return (getNodesNumber() == 0); }
 
-Graph::~Graph() { deleteGraph(); }
-
 int Graph::getNodesNumber() const { return (int)adjacencyList.size(); }
 
 int Graph::getHighestNodeNumber() const {

--- a/source/GraphDrawing/graph.cpp
+++ b/source/GraphDrawing/graph.cpp
@@ -230,7 +230,7 @@ void Graph::DFS(Graph &dfsTree) {
     vertex_map[nodes[i].getNodeNumber()] = true;
 
   // for every vertex marked as new do DFSSearch()
-  for (const std::pair<int, bool> &it : vertex_map)
+  for (const std::pair<int, bool> it : vertex_map)
     if (it.second) {
       dfsTree.addNode(it.first);
       DFSSearch(dfsTree, vertex_map, it.first);

--- a/source/GraphDrawing/graph.h
+++ b/source/GraphDrawing/graph.h
@@ -34,8 +34,6 @@ public:
   Graph(const std::string &);
   //! Copy constructor
   Graph(Graph &);
-  //! destructor
-  ~Graph();
   //! Gets number of nodes
   /*! This function is used to get number of graph nodes
    * \return number of nodes

--- a/source/GraphDrawing/graphnode.cpp
+++ b/source/GraphDrawing/graphnode.cpp
@@ -31,14 +31,6 @@ bool GraphNode::operator!=(const GraphNode &newGraphNode) const {
   return (*this != newGraphNode);
 }
 
-GraphNode &GraphNode::operator=(const GraphNode &newGraphNode) {
-  if (*this == newGraphNode)
-    return *this;
-  nodeNumber = newGraphNode.nodeNumber;
-  nodeLabel = newGraphNode.nodeLabel;
-  return *this;
-}
-
 bool GraphNode::operator<(const GraphNode &newGraphNode) const {
   return (nodeNumber < newGraphNode.nodeNumber);
 }

--- a/source/GraphDrawing/graphnode.h
+++ b/source/GraphDrawing/graphnode.h
@@ -48,7 +48,6 @@ public:
   void updateNodeLabel();
   bool operator==(const GraphNode &) const;
   bool operator!=(const GraphNode &) const;
-  GraphNode &operator=(const GraphNode &);
   bool operator<(const GraphNode &) const;
   // friend ostream& operator<<(ostream& ostr, const GraphNode& gn);
   // friend istream& operator>>(istream& istr, GraphNode& gn);

--- a/source/Import/JavaView.cpp
+++ b/source/Import/JavaView.cpp
@@ -4,6 +4,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "JavaView.h"
+#include <cmath>
 #include <string.h>
 #if defined(__MACH__)
 #include <stdlib.h>
@@ -1154,27 +1155,10 @@ GReturnValue CJavaView::ReadNumber(double *dNumber) {
   return rvG_OK;
 }
 
-GReturnValue CJavaView::power(double d, int exp, double *result) {
-  bool positive = true;
-
-  *result = 1;
-  if (exp < 0) {
-    positive = false;
-    exp = -exp;
-  }
-  for (int i = 1; i <= exp; i++) {
-    if (positive)
-      (*result) = (*result) * d;
-    else
-      (*result) = (*result) / d;
-  }
-  return rvG_OK;
-}
-
 GReturnValue CJavaView::convert(char *word, double *number) {
   int i = 0, sign = 1;
   double dp = 1.00;
-  double exp = 0, mult;
+  double exp = 0;
   bool decimal = false;
   bool exponent = false;
   char c;
@@ -1198,7 +1182,7 @@ GReturnValue CJavaView::convert(char *word, double *number) {
           iRv = convert(word + i, &exp);
           if (iRv != rvG_OK)
             return iRv;
-          iRv = power(10, (int)exp, &mult);
+          const double mult = pow(10.0, (int)exp);
           (*number) = (*number) * mult;
           return iRv;
         } else {

--- a/source/Import/JavaView.h
+++ b/source/Import/JavaView.h
@@ -95,7 +95,6 @@ private:
 
   GReturnValue ReadNumber(double *dNumber);
   GReturnValue convert(char *word, double *number);
-  GReturnValue power(double d, int exp, double *result);
 
   int m_iLineBeforeLastToken;
   int m_iPositionBeforeLastToken;

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -4,6 +4,7 @@
 
 #include "JavaView.h"
 #include "GCLCInput.h"
+#include <cmath>
 #include <malloc.h>
 #include <string.h>
 
@@ -1352,34 +1353,11 @@ GReturnValue CJavaView::ReadNumber(double *dNumber)
 
 
 
-GReturnValue CJavaView::power(double d, int exp, double *result)
-{
-	bool positive=true;
-
-	*result = 1;
-	if (exp<0) 
-	{
-		positive = false;
-		exp = -exp;
-	}
-	for(int i=1;i<=exp;i++)
-	{
-		if (positive)
-			(*result)=(*result)*10;
-		else
-			(*result)=(*result)/10;
-	}
-	return rvG_OK;
-}
-
-
-
-
 GReturnValue CJavaView::convert(char *word, double *number)
 {
 	int i=0, sign=1;
 	double dp=1.00;
-	double exp=0, mult;
+	double exp=0;
 	bool decimal=false;
 	bool exponent=false;
 	char c;
@@ -1404,7 +1382,7 @@ GReturnValue CJavaView::convert(char *word, double *number)
 					iRv=convert(word+i,&exp);
 					if (iRv!=rvG_OK)
 						return iRv;
-					iRv=power(10,(int)exp,&mult);
+					const double mult=pow(10.0,(int)exp);
 					(*number)=(*number)*mult;
 					return iRv;
 				}

--- a/source/Tools/jv2gcl/JavaView.h
+++ b/source/Tools/jv2gcl/JavaView.h
@@ -112,7 +112,6 @@ private:
 	
 	GReturnValue ReadNumber(double *dNumber);
 	GReturnValue convert(char *word, double *number);
-	GReturnValue power(double d, int exp, double *result);
 
 	int m_iLineBeforeLastToken;
 	int m_iPositionBeforeLastToken;

--- a/source/Utils/Utils.cpp
+++ b/source/Utils/Utils.cpp
@@ -87,7 +87,7 @@ bool convert_int(const std::string &word, int &number) {
 bool convert(const std::string &word, double &number) {
   int i = 0, sign = 1;
   double dp = 1.00;
-  double exp = 0, mult;
+  double exp = 0;
   bool decimal = false;
   bool exponent = false;
   char c;
@@ -115,7 +115,7 @@ bool convert(const std::string &word, double &number) {
           decimal = true;
           if (!convert(word.substr(i), exp))
             return false;
-          power(10, (int)exp, mult);
+          const double mult = pow(10.0, (int)exp);
           number *= mult;
           return true;
         } else
@@ -140,29 +140,6 @@ bool convert(const std::string &word, double &number) {
 
   number *= sign;
   return true;
-}
-
-// ----------------------------------------------------------------------------////
-
-void power(double d, int exp, double &result) {
-  bool positive = true;
-  if (d == 0) {
-    result = 1;
-    return;
-  }
-
-  result = 1;
-  if (exp < 0) {
-    positive = false;
-    exp = -exp;
-  }
-  for (int i = 1; i <= exp; i++) {
-    if (positive)
-      result *= d;
-    else
-      result /= d;
-  }
-  return;
 }
 
 // ----------------------------------------------------------------------------////

--- a/source/Utils/Utils.h
+++ b/source/Utils/Utils.h
@@ -16,7 +16,6 @@ void trimrightzeros(std::string &name);
 bool convert_int(const std::string &word, int &number);
 bool convert(const std::string &word, double &number);
 
-void power(double d, int exp, double &result);
 int log_div(int d, int c);
 
 bool same_point(double x1, double y1, double x2, double y2);


### PR DESCRIPTION
Following the changes in this series, all three of `make`, `cd source && qmake cGCLC.pro && make`, and `cd source && qmake gGCLC.pro && make` complete warning-free on Linux with GCC 11.4.0. We could feasibly apply `-Werror` in CI in future.

----

I ended up here via a conversation with Nikola Ubavić. Nikola mentioned the possibility of using unifying the existing builds into a single CMake build system. Is this something desirable that you all have consensus on? If so, I could take a look at this, but I didn’t want to go down this road if it’s not something you want to do.