### PR TITLE
reduce casting and improve type safety of 'Polynomial' cloning

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -174,7 +174,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
       }
       m1->Dispose();
 
-      xp = (XPolynomial *)vxps[i]->Clone();
+      xp = vxps[i]->Clone();
       xp->SPol(vxps[k]);
       _maxt = MAX2(_maxt, xp->GetTotalTermCount());
 
@@ -506,7 +506,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   c1Clone->Dispose();
   pc1g->AddTerm(tc1g);
   tc1g->Dispose();
-  XPolynomial *xp2Clone = (XPolynomial *)xp2->Clone();
+  XPolynomial *xp2Clone = xp2->Clone();
   xp2Clone->Mul(pc1g);
   pc1g->Dispose();
 
@@ -569,7 +569,7 @@ bool Groebner::GroebnerBasis2(vxp &vxps) {
                           ii, jj);
           continue;
         }
-        XPolynomial *xp = (XPolynomial *)xp1->Clone();
+        XPolynomial *xp = xp1->Clone();
         xp->SPol(xp2);
         // Reduce(xp, xp2);
 

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -160,7 +160,7 @@ bool Reduce::ReduceLineCircleIntersection(
     // (e5) last pol should have factor (x11 - x21)
     // (e6) divide with (x11 - x21)
     Log::PrintLogF(level, "dividing last pol with (x11 - x21) (first - third point):\n\n");
-    XPolynomial* xf = (XPolynomial*)xp11->Clone();
+    XPolynomial* xf = xp11->Clone();
     xf->Subtract(xp21);
     Log::PrintLogF(level, "x11 - x21 = \n\n");
     PolyReader::PrintPolynomial(xf, level);

--- a/source/AlgebraicMethods/UPolynomial.cpp
+++ b/source/AlgebraicMethods/UPolynomial.cpp
@@ -26,7 +26,7 @@ UPolynomial::UPolynomial(REAL cf)
 	COSTR("upoly");
 }
 
-Polynomial* UPolynomial::Clone()
+UPolynomial* UPolynomial::Clone()
 {
 	UPolynomial* upClone = new UPolynomial();
 

--- a/source/AlgebraicMethods/UPolynomial.h
+++ b/source/AlgebraicMethods/UPolynomial.h
@@ -11,7 +11,7 @@ public:
 	~UPolynomial();
 
 	UPolynomial(REAL cf);
-	Polynomial* Clone();
+	UPolynomial* Clone() override;
 
 	TERM_TYPE Type() const;
 

--- a/source/AlgebraicMethods/UPolynomialFraction.cpp
+++ b/source/AlgebraicMethods/UPolynomialFraction.cpp
@@ -36,8 +36,8 @@ UPolynomialFraction* UPolynomialFraction::Clone()
 {
 	UPolynomialFraction* ufClone = new UPolynomialFraction();
 
-	UPolynomial* upNumClone = (UPolynomial*)this->GetNumerator()->Clone();
-	UPolynomial* upDenClone = (UPolynomial*)this->GetDenominator()->Clone();
+	UPolynomial* upNumClone = this->GetNumerator()->Clone();
+	UPolynomial* upDenClone = this->GetDenominator()->Clone();
 
 	ufClone->SetNumerator(upNumClone);
 	upNumClone->Dispose();

--- a/source/AlgebraicMethods/XPolynomial.h
+++ b/source/AlgebraicMethods/XPolynomial.h
@@ -16,7 +16,7 @@ public:
 	~XPolynomial();
 	XPolynomial(REAL x);
 	XPolynomial(bool free, int index);
-	Polynomial* Clone();
+	XPolynomial* Clone() override;
 
 	TERM_TYPE Type() const;
 

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -427,7 +427,7 @@ void XTerm::Merge(Term* t)
 	n1->Mul(d2);
 
 	// create second sumand, n2*d1
-	UPolynomial* n2clone = (UPolynomial*)n2->Clone();
+	UPolynomial* n2clone = n2->Clone();
 	n2clone->Mul(d1);
 
 	// add n2*d1 to the n1

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -116,7 +116,7 @@ XPolynomial *XPolynomial::CreatePolynomialCondition(bool f1, uint index1,
   return xp;
 }
 
-Polynomial *XPolynomial::Clone() {
+XPolynomial *XPolynomial::Clone() {
   XPolynomial *xpClone = new XPolynomial();
 
   _terms->EnumReset();
@@ -376,7 +376,7 @@ bool XPolynomial::_PseudoRemainder(XPolynomial *xp, int index, bool free,
   Log::PrintLogF(logLevel, "lm1(q, x%d) = \n", index);
   PolyReader::PrintPolynomial(q, logLevel);
 
-  XPolynomial *xpClone = (XPolynomial *)xp->Clone();
+  XPolynomial *xpClone = xp->Clone();
   xpClone->Mul(p);
 
   Log::PrintLogF(logLevel, "p1 * lm(p0) = \n");


### PR DESCRIPTION
C++ supports so-called “covariant return types”¹ that permit an overriding function to return a “narrower” type than its parent. This allows implementing a copying helper that (1) returns a more precise type and (2) does not require casting at the call site, thus removing an opportunity for mistakes. This change allows the compiler to validate calls to `Polynomial::clone` and its children.

¹ https://en.wikipedia.org/wiki/Covariant_return_type

----

If this is a reasonable change to make, we could look at doing the same to the other hierarchies like `Term`.