### PR TITLE
remove use of 'alloca'

### DIFF
--- a/source/Import/JavaView.cpp
+++ b/source/Import/JavaView.cpp
@@ -5,6 +5,7 @@
 
 #include "JavaView.h"
 #include <cmath>
+#include <string>
 #include <string.h>
 #if defined(__MACH__)
 #include <stdlib.h>
@@ -74,7 +75,7 @@ GReturnValue CJavaView::Import(CGCLCInput *pInput,
 }
 
 GReturnValue CJavaView::ReadModel() {
-  char *word, *commandname;
+  char *word;
   GReturnValue iRv, err;
   JavaViewcommands com;
   do {
@@ -98,10 +99,7 @@ GReturnValue CJavaView::ReadModel() {
     if (!strcmp(word, JVTagName[_jv_jvx_model][1]))
       return rvG_OK;
 
-    commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -171,10 +169,7 @@ GReturnValue CJavaView::ReadGeometry() {
     if (!strcmp(word, JVTagName[_jv_geometry][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -216,10 +211,7 @@ GReturnValue CJavaView::ReadPointSet() {
   do {
     iRv = GetToken(&word);
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (!strcmp(word, JVTagName[_jv_pointset][1])) {
       struct point *pPoint;
@@ -296,10 +288,7 @@ GReturnValue CJavaView::ReadPoints() {
     if (!strcmp(word, JVTagName[_jv_points][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -454,10 +443,7 @@ GReturnValue CJavaView::ReadFaceSet() {
       return rvG_OK;
     }
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -496,10 +482,7 @@ GReturnValue CJavaView::ReadFaces() {
     if (!strcmp(word, JVTagName[_jv_faces][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -575,10 +558,7 @@ GReturnValue CJavaView::ReadLineSet() {
     if (!strcmp(word, JVTagName[_jv_lineset][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -613,10 +593,7 @@ GReturnValue CJavaView::ReadLines() {
     if (!strcmp(word, JVTagName[_jv_lines][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -666,11 +643,8 @@ GReturnValue CJavaView::ReadL() {
     char *endsubstring = substring + 5;
     while (*endsubstring != '"')
       endsubstring++;
-    char *name = (char *)alloca(endsubstring - substring - 4);
-    if (name == NULL)
-      return rvG_OutOfMemory;
-    strncpy(name, substring + 5, endsubstring - substring - 5);
-    name[endsubstring - substring - 5] = '\0';
+    const std::string name{substring + 5,
+                           static_cast<size_t>(endsubstring - substring - 5)};
 
     sprintf(m_sOutput, "midpoint M%i_%i_%i_%i P%i_%i P%i_%i", m_iGeometryIndex,
             (int)(iFirst + 1), m_iGeometryIndex, (int)(iSecond + 1),
@@ -679,7 +653,7 @@ GReturnValue CJavaView::ReadL() {
     Output(m_sOutput);
 
     sprintf(m_sOutput, "printat_t M%i_%i_%i_%i {%s}", m_iGeometryIndex,
-            (int)(iFirst + 1), m_iGeometryIndex, (int)(iSecond + 1), name);
+            (int)(iFirst + 1), m_iGeometryIndex, (int)(iSecond + 1), name.c_str());
     Output(m_sOutput);
   }
 
@@ -702,10 +676,7 @@ GReturnValue CJavaView::ReadVectorField() {
     if (!strcmp(word, JVTagName[_jv_vectorfield][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -747,10 +718,7 @@ GReturnValue CJavaView::ReadVectors() {
     if (!strcmp(word, JVTagName[_jv_vectors][1]))
       return rvG_OK;
 
-    char *commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -832,7 +800,7 @@ GReturnValue CJavaView::ReadThickness() {
 }
 
 GReturnValue CJavaView::ReadColors() {
-  char *word, *commandname;
+  char *word;
   GReturnValue iRv, err;
   JavaViewcommands com;
 
@@ -841,10 +809,7 @@ GReturnValue CJavaView::ReadColors() {
     if (!strcmp(word, JVTagName[_jv_colors][1]))
       return rvG_OK;
 
-    commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -866,7 +831,7 @@ GReturnValue CJavaView::ReadColors() {
 }
 
 GReturnValue CJavaView::ReadFaceColors() {
-  char *word, *commandname;
+  char *word;
   GReturnValue iRv, err;
   JavaViewcommands com;
 
@@ -875,10 +840,7 @@ GReturnValue CJavaView::ReadFaceColors() {
     if (!strcmp(word, JVTagName[_jv_colors][1]))
       return rvG_OK;
 
-    commandname = (char *)alloca(strlen(word) + 1);
-    if (commandname == NULL)
-      return rvG_OutOfMemory;
-    strcpy(commandname, word);
+    const std::string commandname{word};
 
     if (iRv != rvG_EndOfData) {
       m_sParams[0] = '\0';
@@ -979,23 +941,18 @@ JavaViewcommands CJavaView::choose_command(char *word, char *params) {
   return _jv_unsupportedcommand;
 }
 
-GReturnValue CJavaView::skip(char *commandname) {
+GReturnValue CJavaView::skip(const std::string &commandname) {
   char *word;
-  char *endcommandname;
 
-  endcommandname = (char *)alloca(strlen(commandname) + 3);
-  strcpy(endcommandname, "</");
-  strncpy(endcommandname + 2, commandname + 1, strlen(commandname) - 1);
-  if (commandname[strlen(commandname) - 1] != '>')
-    strcpy(endcommandname + 2 + strlen(commandname) - 1, ">");
-  else
-    strcpy(endcommandname + 2 + strlen(commandname) - 1, "");
+  std::string endcommandname{"</" + commandname.substr(1)};
+  if (!commandname.empty() && commandname[commandname.size() - 1] != '>')
+    endcommandname += ">";
 
   GReturnValue iRv;
   do {
     iRv = GetToken(&word);
     if (iRv != rvG_EndOfData) {
-      if (!strcmp(word, endcommandname))
+      if (word == endcommandname)
         return rvG_OK;
     }
   } while (iRv != rvG_EndOfData);

--- a/source/Import/JavaView.h
+++ b/source/Import/JavaView.h
@@ -2,6 +2,7 @@
 #include "Input/GCLCInput.h"
 #include "ListOfFaces.h"
 #include <QTextEdit>
+#include <string>
 
 #if !defined(JAVAVIEW_H)
 #define JAVAVIEW_H
@@ -66,7 +67,7 @@ private:
   GReturnValue GetToken(char **psToken);
 
   JavaViewcommands choose_command(char *word, char *params);
-  GReturnValue skip(char *commandname);
+  GReturnValue skip(const std::string &commandname);
   void AttachNames();
 
   GReturnValue ReadModel();

--- a/source/Logging/DummyLog.cpp
+++ b/source/Logging/DummyLog.cpp
@@ -10,10 +10,10 @@ CDummyLog::CDummyLog() {}
 
 // ----------------------------------------------------------------------------
 
-void CDummyLog::Reset() { return; }
+void CDummyLog::Reset() { }
 
 // ----------------------------------------------------------------------------
 
-void CDummyLog::AddText(const std::string & /* pText */) { return; }
+void CDummyLog::AddText(const std::string & /* pText */) { }
 
 // ----------------------------------------------------------------------------

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -6,6 +6,7 @@
 #include "GCLCInput.h"
 #include <cmath>
 #include <malloc.h>
+#include <string>
 #include <string.h>
 
 #define X_OFF 70
@@ -94,7 +95,7 @@ GReturnValue CJavaView::Import(CGCLCInput *pInput, FILE *hOutput)
 
 GReturnValue CJavaView::ReadModel()
 {
-	char *word, *commandname;
+	char *word;
 	GReturnValue iRv,err;
 	JavaViewcommands com;
 	do 
@@ -123,10 +124,7 @@ GReturnValue CJavaView::ReadModel()
 		if (!strcmp(word,JVTagName[_jv_jvx_model][1]))
 			return rvG_OK;
 
-		commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -208,10 +206,7 @@ GReturnValue CJavaView::ReadGeometry()
 		if (!strcmp(word,JVTagName[_jv_geometry][1]))
 			return rvG_OK;
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -256,10 +251,7 @@ GReturnValue CJavaView::ReadPointSet()
 	{
 		iRv=GetToken(&word);
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (!strcmp(word,JVTagName[_jv_pointset][1]))
 		{
@@ -340,11 +332,7 @@ GReturnValue CJavaView::ReadPoints()
 		if (!strcmp(word,JVTagName[_jv_points][1]))
 			return rvG_OK;
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
-
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -520,10 +508,7 @@ GReturnValue CJavaView::ReadFaceSet()
 			return rvG_OK; 
 		}
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -567,11 +552,7 @@ GReturnValue CJavaView::ReadFaces()
 		if (!strcmp(word,JVTagName[_jv_faces][1]))
 			return rvG_OK;
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
-
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -661,11 +642,7 @@ GReturnValue CJavaView::ReadLineSet()
 		if (!strcmp(word,JVTagName[_jv_lineset][1]))
 			return rvG_OK; 
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
-
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -706,10 +683,7 @@ GReturnValue CJavaView::ReadLines()
 		if (!strcmp(word,JVTagName[_jv_lines][1]))
 			return rvG_OK;
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -764,18 +738,15 @@ GReturnValue CJavaView::ReadL()
 		char* endsubstring=substring+5;
 		while(*endsubstring != '"')
 			endsubstring++;
-		char* name=(char*)alloca(endsubstring-substring-4);
-		if (name==NULL)
-			return rvG_OutOfMemory;
-		strncpy(name, substring+5, endsubstring-substring-5);
-		name[endsubstring-substring-5]='\0';
+		const std::string name{substring + 5,
+		                       static_cast<size_t>(endsubstring - substring - 5)};
 
 		sprintf(m_sOutput,"midpoint M%i_%i_%i_%i P%i_%i P%i_%i",
 			m_iGeometryIndex, (int)(iFirst+1), m_iGeometryIndex, (int)(iSecond+1),
 			m_iGeometryIndex, (int)(iFirst+1), m_iGeometryIndex, (int)(iSecond+1));
 		Output(m_sOutput);
 
-		sprintf(m_sOutput,"printat_t M%i_%i_%i_%i {%s}",m_iGeometryIndex, (int)(iFirst+1), m_iGeometryIndex, (int)(iSecond+1),name);
+		sprintf(m_sOutput,"printat_t M%i_%i_%i_%i {%s}",m_iGeometryIndex, (int)(iFirst+1), m_iGeometryIndex, (int)(iSecond+1), name.c_str());
 		Output(m_sOutput);
 	}
 
@@ -806,10 +777,7 @@ GReturnValue CJavaView::ReadVectorField()
 		if (!strcmp(word,JVTagName[_jv_vectorfield][1]))
 			return rvG_OK; 
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -856,10 +824,7 @@ GReturnValue CJavaView::ReadVectors()
 		if (!strcmp(word,JVTagName[_jv_vectors][1]))
 			return rvG_OK;
 
-		char* commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -957,7 +922,7 @@ GReturnValue CJavaView::ReadThickness()
 
 GReturnValue CJavaView::ReadColors()
 {
-	char *word, *commandname;
+	char *word;
 	GReturnValue iRv,err;
 	JavaViewcommands com;
 
@@ -970,11 +935,7 @@ GReturnValue CJavaView::ReadColors()
 		if (!strcmp(word,JVTagName[_jv_colors][1]))
 			return rvG_OK;
 
-		commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
-
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -1001,7 +962,7 @@ GReturnValue CJavaView::ReadColors()
 
 GReturnValue CJavaView::ReadFaceColors()
 {
-	char *word, *commandname;
+	char *word;
 	GReturnValue iRv,err;
 	JavaViewcommands com;
 	
@@ -1014,10 +975,7 @@ GReturnValue CJavaView::ReadFaceColors()
 		if (!strcmp(word,JVTagName[_jv_colors][1]))
 			return rvG_OK;
 
-		commandname = (char*)alloca(strlen(word)+1);
-		if (commandname == NULL)
-			return rvG_OutOfMemory;
-		strcpy(commandname,word);
+		const std::string commandname{word};
 
 		if (iRv!=rvG_EndOfData) 
 		{
@@ -1139,22 +1097,13 @@ JavaViewcommands CJavaView::choose_command(char* word,char* params)
 	return _jv_unsupportedcommand;
 }
 
-
-
-
-
-GReturnValue  CJavaView::skip(char* commandname)
+GReturnValue  CJavaView::skip(const std::string &commandname)
 {
 	char *word;
-	char *endcommandname;
 
-	endcommandname = (char*)alloca(strlen(commandname)+3);
-	strcpy(endcommandname, "</");
-	strncpy(endcommandname+2, commandname+1, strlen(commandname)-1);
-	if (commandname[strlen(commandname)-1]!='>')
-		strcpy(endcommandname+2+strlen(commandname)-1, ">");
-	else
-		strcpy(endcommandname+2+strlen(commandname)-1, "");
+	std::string endcommandname{"</" + commandname.substr(1)};
+	if (!commandname.empty() && commandname[commandname.size() - 1] != '>')
+		endcommandname += ">";
 
 	GReturnValue iRv;
 	do 
@@ -1162,7 +1111,7 @@ GReturnValue  CJavaView::skip(char* commandname)
 		iRv=GetToken(&word);
 		if (iRv!=rvG_EndOfData) 
 		{
-			if (!strcmp(word,endcommandname)) 
+			if (word == endcommandname)
 				return rvG_OK;
 		}
 	}

--- a/source/Tools/jv2gcl/JavaView.h
+++ b/source/Tools/jv2gcl/JavaView.h
@@ -9,6 +9,7 @@
 #include "gcompiler.h"
 #include "GCLCInput.h"
 #include "FileInput.h"
+#include <string>
 
 #include "ListOfFaces.h"
 
@@ -82,7 +83,7 @@ private:
 	GReturnValue GetToken(char **psToken);
 
 	JavaViewcommands choose_command(char* word,char* params);
-	GReturnValue  skip(char* commandname);
+	GReturnValue  skip(const std::string &commandname);
 	void AttachNames();
 
 	


### PR DESCRIPTION
The `alloca` function allocates memory on the stack. If the requested size is
too large, a silent stack overflow occurs and the program will crash or
misbehave. In this case where the allocated size is not known statically, it is
safer to use `std::string`. Small String Optimization¹ also means short command
names will still be stack-allocated when possible.

¹ https://pvs-studio.com/en/blog/terms/6658/