### PR TITLE
simplify 'CFace' vertex management

### DIFF
--- a/source/Import/JavaView.cpp
+++ b/source/Import/JavaView.cpp
@@ -524,8 +524,7 @@ GReturnValue CJavaView::ReadF() {
     if (iRv != rvG_OK)
       return iRv;
 
-    if (!m_ListOfFaces.AddNewVertex((int)number + 1))
-      return rvG_OutOfMemory;
+    m_ListOfFaces.AddNewVertex((int)number + 1);
 
     iRv = GetToken(&word);
     if (iRv != rvG_OK)

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -85,49 +85,23 @@ void CListOfFaces::SetLastFaceName(const std::string &sName) {
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-CFace::CFace() { m_pFirstVertex = NULL; }
-
-CFace::~CFace() {
-  struct vertex *pVertex, *pV;
-
-  pVertex = m_pFirstVertex;
-
-  while (pVertex != NULL) {
-    pV = pVertex->pnext;
-    delete pVertex;
-    pVertex = pV;
-  }
-}
+CFace::CFace() { m_iCurrentVertex = 0; }
 
 bool CFace::AddNewVertex(int uIndex) {
-  struct vertex *pVertex;
-
-  pVertex = new vertex;
-  if (pVertex == NULL)
-    return false;
-
-  pVertex->index = uIndex;
-  pVertex->pnext = NULL;
-
-  if (m_pFirstVertex == NULL)
-    m_pFirstVertex = pVertex;
-  else
-    m_pLastVertex->pnext = pVertex;
-
-  m_pLastVertex = pVertex;
-
+  vertex vVertex = {.index = uIndex};
+  m_vVertices.push_back(vVertex);
   return true;
 }
 
 struct vertex *CFace::GetFirstVertex() {
-  m_pCurrentVertex = m_pFirstVertex;
-  return m_pCurrentVertex;
+  m_iCurrentVertex = 0;
+  return m_vVertices.empty() ? nullptr : &m_vVertices.front();
 }
 
 struct vertex *CFace::GetNextVertex() {
-  if (m_pCurrentVertex != NULL) {
-    m_pCurrentVertex = m_pCurrentVertex->pnext;
-    return m_pCurrentVertex;
+  if (m_iCurrentVertex + 1 < m_vVertices.size()) {
+    ++m_iCurrentVertex;
+    return &m_vVertices[m_iCurrentVertex];
   } else
     return NULL;
 }

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -55,8 +55,8 @@ bool CListOfFaces::AddNewFace() {
   return true;
 }
 
-bool CListOfFaces::AddNewVertex(int uIndex) {
-  return m_pLastFace->AddNewVertex(uIndex);
+void CListOfFaces::AddNewVertex(int uIndex) {
+  m_pLastFace->AddNewVertex(uIndex);
 }
 
 void CListOfFaces::AttachColorsToCurrentFace(unsigned char r, unsigned char g,
@@ -87,10 +87,9 @@ void CListOfFaces::SetLastFaceName(const std::string &sName) {
 
 CFace::CFace() { m_iCurrentVertex = 0; }
 
-bool CFace::AddNewVertex(int uIndex) {
+void CFace::AddNewVertex(int uIndex) {
   vertex vVertex = {.index = uIndex};
   m_vVertices.push_back(vVertex);
-  return true;
 }
 
 struct vertex *CFace::GetFirstVertex() {

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -55,7 +55,7 @@ bool CListOfFaces::AddNewFace() {
   return true;
 }
 
-bool CListOfFaces::AddNewVertex(unsigned int uIndex) {
+bool CListOfFaces::AddNewVertex(int uIndex) {
   return m_pLastFace->AddNewVertex(uIndex);
 }
 
@@ -99,7 +99,7 @@ CFace::~CFace() {
   }
 }
 
-bool CFace::AddNewVertex(unsigned int uIndex) {
+bool CFace::AddNewVertex(int uIndex) {
   struct vertex *pVertex;
 
   pVertex = new vertex;

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -31,7 +31,7 @@ class CFace {
 
 public:
   CFace();
-  bool AddNewVertex(int uIndex);
+  void AddNewVertex(int uIndex);
   unsigned char GetRColor() { return r; };
   unsigned char GetGColor() { return g; }
   unsigned char GetBColor() { return b; }
@@ -61,7 +61,7 @@ public:
   void DeleteAll();
   void SetGeometryIndex(unsigned int uIndex);
   bool AddNewFace();
-  bool AddNewVertex(int uIndex);
+  void AddNewVertex(int uIndex);
   CFace *GetFirstFace();
   CFace *GetNextFace();
   int GetGeometry() { return m_iGeometry; }

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -18,7 +18,6 @@ struct javaviewface {
 
 struct vertex {
   int index;
-  struct vertex *pnext;
 };
 
 struct point {
@@ -32,7 +31,6 @@ class CFace {
 
 public:
   CFace();
-  virtual ~CFace();
   bool AddNewVertex(int uIndex);
   unsigned char GetRColor() { return r; };
   unsigned char GetGColor() { return g; }
@@ -51,7 +49,8 @@ private:
   unsigned char r, g, b;
 
   bool m_bVisible;
-  struct vertex *m_pFirstVertex, *m_pCurrentVertex, *m_pLastVertex;
+  std::vector<vertex> m_vVertices;
+  size_t m_iCurrentVertex;
   CFace *m_pNextFace;
 };
 

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -33,7 +33,7 @@ class CFace {
 public:
   CFace();
   virtual ~CFace();
-  bool AddNewVertex(unsigned int uIndex);
+  bool AddNewVertex(int uIndex);
   unsigned char GetRColor() { return r; };
   unsigned char GetGColor() { return g; }
   unsigned char GetBColor() { return b; }
@@ -62,7 +62,7 @@ public:
   void DeleteAll();
   void SetGeometryIndex(unsigned int uIndex);
   bool AddNewFace();
-  bool AddNewVertex(unsigned int uIndex);
+  bool AddNewVertex(int uIndex);
   CFace *GetFirstFace();
   CFace *GetNextFace();
   int GetGeometry() { return m_iGeometry; }

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -611,8 +611,7 @@ GReturnValue CJavaView::ReadF()
 		if (iRv!=rvG_OK) 
 			return iRv;
 
-		if (!m_ListOfFaces.AddNewVertex((int)number+1))
-			return rvG_OutOfMemory;
+		m_ListOfFaces.AddNewVertex((int)number + 1);
 
 		iRv=GetToken(&word);
 		if (iRv!=rvG_OK)

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -493,7 +493,7 @@ GReturnValue CJavaView::ReadFaceSet()
 					sprintf(m_sOutput,"towards P%i_label P%i_%i P%i_label %3.2f",
 						m_ListOfFaces.GetGeometry(), 
 						m_ListOfFaces.GetGeometry(), uFirstIndex,
-						m_ListOfFaces.GetGeometry(), (double)(1.0/(iNumberOfVerteces+1)));
+						m_ListOfFaces.GetGeometry(), 1.0 / (iNumberOfVerteces + 1));
 					Output(m_sOutput);
 
 					sprintf(m_sOutput,"printat P%i_label {%s}",m_iGeometryIndex, pFace->name); 

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -118,42 +118,13 @@ void CListOfFaces::SetLastFaceName(char* sName)
 
 CFace::CFace()
 {
-	m_pFirstVertex = NULL;
-}
-
-
-CFace::~CFace()
-{
-	struct vertex *pVertex, *pV;
-
-	pVertex= m_pFirstVertex;
-
-	while(pVertex!=NULL)
-	{
-		pV = pVertex->pnext;
-		delete pVertex;
-		pVertex = pV;
-	}
+	m_iCurrentVertex = 0;
 }
 
 bool CFace::AddNewVertex(int uIndex)
 {
-	struct vertex *pVertex;
-
-	pVertex= new vertex;
-	if (pVertex == NULL) 
-		return false;
-
-	pVertex->index = uIndex;
-	pVertex->pnext = NULL;
-	
-	if(m_pFirstVertex==NULL)
-		m_pFirstVertex = pVertex;
-	else
-		m_pLastVertex->pnext = pVertex;		
-
-	m_pLastVertex=pVertex;
-	
+	vertex vVertex = {.index = uIndex};
+	m_vVertices.push_back(vVertex);
 	return true;
 }
 
@@ -161,17 +132,17 @@ bool CFace::AddNewVertex(int uIndex)
 
 struct vertex* CFace::GetFirstVertex()
 {
-	m_pCurrentVertex = m_pFirstVertex;
-	return m_pCurrentVertex;
+	m_iCurrentVertex = 0;
+	return m_vVertices.empty() ? nullptr : &m_vVertices.front();
 }
 
 
 struct vertex* CFace::GetNextVertex()
 {
-	if (m_pCurrentVertex!=NULL)
+	if (m_iCurrentVertex + 1 < m_vVertices.size())
 	{
-		m_pCurrentVertex = m_pCurrentVertex->pnext;
-		return m_pCurrentVertex;
+		++m_iCurrentVertex;
+		return &m_vVertices[m_iCurrentVertex];
 	}
 	else
 		return NULL;

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -72,9 +72,9 @@ bool CListOfFaces::AddNewFace()
 	return true;
 }
 
-bool CListOfFaces::AddNewVertex(int uIndex)
+void CListOfFaces::AddNewVertex(int uIndex)
 {
-	return m_pLastFace->AddNewVertex(uIndex);
+	m_pLastFace->AddNewVertex(uIndex);
 }
 
 
@@ -121,11 +121,10 @@ CFace::CFace()
 	m_iCurrentVertex = 0;
 }
 
-bool CFace::AddNewVertex(int uIndex)
+void CFace::AddNewVertex(int uIndex)
 {
 	vertex vVertex = {.index = uIndex};
 	m_vVertices.push_back(vVertex);
-	return true;
 }
 
 

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -72,8 +72,7 @@ bool CListOfFaces::AddNewFace()
 	return true;
 }
 
-		
-bool CListOfFaces::AddNewVertex(unsigned int uIndex)
+bool CListOfFaces::AddNewVertex(int uIndex)
 {
 	return m_pLastFace->AddNewVertex(uIndex);
 }
@@ -137,8 +136,7 @@ CFace::~CFace()
 	}
 }
 
-
-bool CFace::AddNewVertex(unsigned int uIndex)
+bool CFace::AddNewVertex(int uIndex)
 {
 	struct vertex *pVertex;
 

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -21,7 +21,6 @@ struct javaviewface
 struct vertex
 {
 	int index;
-	struct vertex* pnext;
 };
 
 
@@ -38,7 +37,6 @@ friend class CListOfFaces;
 
 public:
 	CFace();
-	virtual ~CFace();
 	bool AddNewVertex(int uIndex);
 	unsigned char GetRColor() { return r; };
 	unsigned char GetGColor() { return g; }
@@ -52,7 +50,8 @@ private:
 	unsigned char r,g,b;
 
 	bool m_bVisible;
-	struct vertex *m_pFirstVertex, *m_pCurrentVertex, *m_pLastVertex;
+	std::vector<vertex> m_vVertices;
+	size_t m_iCurrentVertex;
 	CFace* m_pNextFace;
 };
 

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -37,7 +37,7 @@ friend class CListOfFaces;
 
 public:
 	CFace();
-	bool AddNewVertex(int uIndex);
+	void AddNewVertex(int uIndex);
 	unsigned char GetRColor() { return r; };
 	unsigned char GetGColor() { return g; }
 	unsigned char GetBColor() { return b; }
@@ -65,7 +65,7 @@ public:
 	void DeleteAll();
 	void SetGeometryIndex(unsigned int uIndex);
 	bool AddNewFace();
-	bool AddNewVertex(int uIndex);
+	void AddNewVertex(int uIndex);
 	CFace* GetFirstFace();
 	CFace* GetNextFace();
 	int GetGeometry() { return m_iGeometry; }

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -39,7 +39,7 @@ friend class CListOfFaces;
 public:
 	CFace();
 	virtual ~CFace();
-	bool AddNewVertex(unsigned int uIndex);
+	bool AddNewVertex(int uIndex);
 	unsigned char GetRColor() { return r; };
 	unsigned char GetGColor() { return g; }
 	unsigned char GetBColor() { return b; }
@@ -66,7 +66,7 @@ public:
 	void DeleteAll();
 	void SetGeometryIndex(unsigned int uIndex);
 	bool AddNewFace();
-	bool AddNewVertex(unsigned int uIndex);
+	bool AddNewVertex(int uIndex);
 	CFace* GetFirstFace();
 	CFace* GetNextFace();
 	int GetGeometry() { return m_iGeometry; }


### PR DESCRIPTION
In surveying the C-style casts in the code base, the next candidate that looks like it can be removed is the mallocing code in `CJavaView::ReadF`. This goes on to operate on a `CListOfFaces` which contains `CFace`s which in turn contain `vertex`s. So it made sense to start reducing complexity from the “bottom” here and work our way up to making `CFace::name` a `std::string`. Rather than try to land all of this at once, this PR just tackles the initial changes simplifying `vertex` and its usages.