### PR TITLE
find Bash via 'env'

### DIFF
--- a/test/compare_outputs.sh
+++ b/test/compare_outputs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 compare_outputs() {
     echo $3


### PR DESCRIPTION
If we ever want to run this script on a platform where Bash does not live at /bin/bash (e.g. FreeBSD), this shebang is slightly more portable.