### PR TITLE
remove manual memory management of 'CFace::name'

### DIFF
--- a/source/Import/JavaView.cpp
+++ b/source/Import/JavaView.cpp
@@ -502,8 +502,7 @@ GReturnValue CJavaView::ReadF() {
   double number;
   char *word;
 
-  if (!m_ListOfFaces.AddNewFace())
-    return rvG_OutOfMemory;
+  m_ListOfFaces.AddNewFace();
 
   char *substring = strstr(m_sParams, "name=");
   if (substring != NULL) {

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -113,8 +113,6 @@ CListOfPoints::CListOfPoints() {
   m_iCurrentPoint = 0;
 }
 
-CListOfPoints::~CListOfPoints() { DeleteAll(); }
-
 void CListOfPoints::DeleteAll() {
   m_iCurrentPoint = 0;
   m_vPoints.clear();

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -21,7 +21,7 @@ void CListOfFaces::SetGeometryIndex(unsigned int uIndex) {
   m_iGeometry = uIndex;
 }
 
-bool CListOfFaces::AddNewFace() {
+void CListOfFaces::AddNewFace() {
   CFace pFace;
 
   pFace.r = 0;
@@ -29,8 +29,6 @@ bool CListOfFaces::AddNewFace() {
   pFace.b = 0;
 
   m_vFaces.push_back(pFace);
-
-  return true;
 }
 
 void CListOfFaces::AddNewVertex(int uIndex) {

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -116,6 +116,7 @@ CListOfPoints::CListOfPoints() {
 CListOfPoints::~CListOfPoints() { DeleteAll(); }
 
 void CListOfPoints::DeleteAll() {
+  m_iCurrentPoint = 0;
   m_vPoints.clear();
 }
 

--- a/source/Import/ListOfFaces.cpp
+++ b/source/Import/ListOfFaces.cpp
@@ -9,24 +9,12 @@
 //////////////////////////////////////////////////////////////////////
 
 CListOfFaces::CListOfFaces() {
-  m_pFirstFace = NULL;
-  m_pLastFace = NULL;
+  m_iCurrentFace = 0;
 }
 
-CListOfFaces::~CListOfFaces() { DeleteAll(); }
-
 void CListOfFaces::DeleteAll() {
-  CFace *pFace, *pF;
-
-  pFace = m_pFirstFace;
-
-  while (pFace != NULL) {
-    pF = pFace->m_pNextFace;
-    delete pFace;
-    pFace = pF;
-  }
-  m_pFirstFace = NULL;
-  m_pLastFace = NULL;
+  m_vFaces.clear();
+  m_iCurrentFace = 0;
 }
 
 void CListOfFaces::SetGeometryIndex(unsigned int uIndex) {
@@ -34,51 +22,41 @@ void CListOfFaces::SetGeometryIndex(unsigned int uIndex) {
 }
 
 bool CListOfFaces::AddNewFace() {
-  CFace *pFace;
+  CFace pFace;
 
-  pFace = new CFace;
-  if (pFace == NULL)
-    return false;
+  pFace.r = 0;
+  pFace.g = 0;
+  pFace.b = 0;
 
-  pFace->m_pNextFace = NULL;
-  pFace->r = 0;
-  pFace->g = 0;
-  pFace->b = 0;
-
-  if (m_pFirstFace == NULL)
-    m_pFirstFace = pFace;
-  else
-    m_pLastFace->m_pNextFace = pFace;
-
-  m_pLastFace = pFace;
+  m_vFaces.push_back(pFace);
 
   return true;
 }
 
 void CListOfFaces::AddNewVertex(int uIndex) {
-  m_pLastFace->AddNewVertex(uIndex);
+  m_vFaces.back().AddNewVertex(uIndex);
 }
 
 void CListOfFaces::AttachColorsToCurrentFace(unsigned char r, unsigned char g,
                                              unsigned char b) {
-  m_pCurrentFace->AttachColors(r, g, b);
+  m_vFaces[m_iCurrentFace].AttachColors(r, g, b);
 }
 
 CFace *CListOfFaces::GetFirstFace() {
-  m_pCurrentFace = m_pFirstFace;
-  return m_pCurrentFace;
+  m_iCurrentFace = 0;
+  return m_vFaces.empty() ? nullptr : &m_vFaces.front();
 }
 
 CFace *CListOfFaces::GetNextFace() {
-  if (m_pCurrentFace != NULL) {
-    m_pCurrentFace = m_pCurrentFace->m_pNextFace;
-    return m_pCurrentFace;
+  if (m_iCurrentFace + 1 < m_vFaces.size()) {
+    ++m_iCurrentFace;
+    return &m_vFaces[m_iCurrentFace];
   } else
     return NULL;
 }
 
 void CListOfFaces::SetLastFaceName(const std::string &sName) {
-  m_pLastFace->name = sName;
+  m_vFaces.back().name = sName;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -77,7 +77,6 @@ private:
 class CListOfPoints {
 public:
   CListOfPoints();
-  virtual ~CListOfPoints();
   void DeleteAll();
   bool AddNewPoint(double x, double y, unsigned char r, unsigned char g,
                    unsigned char b);

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -9,13 +9,6 @@
 #include <string>
 #include <vector>
 
-struct javaviewface {
-  int geometry;
-  int v1, v2, v3, v4;
-  unsigned char r, g, b;
-  bool visible;
-};
-
 struct vertex {
   int index;
 };

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -32,7 +32,7 @@ class CFace {
 public:
   CFace();
   void AddNewVertex(int uIndex);
-  unsigned char GetRColor() { return r; };
+  unsigned char GetRColor() { return r; }
   unsigned char GetGColor() { return g; }
   unsigned char GetBColor() { return b; }
 

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -51,13 +51,11 @@ private:
   bool m_bVisible;
   std::vector<vertex> m_vVertices;
   size_t m_iCurrentVertex;
-  CFace *m_pNextFace;
 };
 
 class CListOfFaces {
 public:
   CListOfFaces();
-  virtual ~CListOfFaces();
   void DeleteAll();
   void SetGeometryIndex(unsigned int uIndex);
   bool AddNewFace();
@@ -71,7 +69,8 @@ public:
 
 private:
   int m_iGeometry;
-  CFace *m_pFirstFace, *m_pCurrentFace, *m_pLastFace;
+  std::vector<CFace> m_vFaces;
+  size_t m_iCurrentFace;
 };
 
 class CListOfPoints {

--- a/source/Import/ListOfFaces.h
+++ b/source/Import/ListOfFaces.h
@@ -58,7 +58,7 @@ public:
   CListOfFaces();
   void DeleteAll();
   void SetGeometryIndex(unsigned int uIndex);
-  bool AddNewFace();
+  void AddNewFace();
   void AddNewVertex(int uIndex);
   CFace *GetFirstFace();
   CFace *GetNextFace();

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -5,7 +5,6 @@
 #include "JavaView.h"
 #include "GCLCInput.h"
 #include <cmath>
-#include <malloc.h>
 #include <string>
 #include <string.h>
 
@@ -451,7 +450,7 @@ GReturnValue CJavaView::ReadFaceSet()
 				unsigned int uFirstIndex = pVertex->index;
 				pVertex = pFace->GetNextVertex();
 
-				if (pFace->name!=NULL)
+				if (pFace->name != "")
 				{
 					sprintf(m_sOutput,"translate P%i_label P%i_%i P%i_%i P%i_%i",
 						m_ListOfFaces.GetGeometry(),
@@ -469,7 +468,7 @@ GReturnValue CJavaView::ReadFaceSet()
 						m_ListOfFaces.GetGeometry(), pVertex->index);
 					Output(m_sOutput);
 
-					if (pFace->name!=NULL)
+					if (pFace->name != "")
 					{
 						sprintf(m_sOutput,"translate P%i_label P%i_%i P%i_%i P%i_label",
 							m_ListOfFaces.GetGeometry(),
@@ -488,7 +487,7 @@ GReturnValue CJavaView::ReadFaceSet()
 					m_ListOfFaces.GetGeometry(), uFirstIndex);
 				Output(m_sOutput);
 
-				if (pFace->name!=NULL)
+				if (pFace->name != "")
 				{
 					sprintf(m_sOutput,"towards P%i_label P%i_%i P%i_label %3.2f",
 						m_ListOfFaces.GetGeometry(), 
@@ -496,7 +495,8 @@ GReturnValue CJavaView::ReadFaceSet()
 						m_ListOfFaces.GetGeometry(), 1.0 / (iNumberOfVerteces + 1));
 					Output(m_sOutput);
 
-					sprintf(m_sOutput,"printat P%i_label {%s}",m_iGeometryIndex, pFace->name); 
+					sprintf(m_sOutput, "printat P%i_label {%s}", m_iGeometryIndex,
+					        pFace->name.c_str());
 					Output(m_sOutput);
 				}
 
@@ -592,11 +592,8 @@ GReturnValue CJavaView::ReadF()
 		char* endsubstring=substring+5;
 		while(*endsubstring != '"')
 			endsubstring++;
-		char* name=(char*)malloc(endsubstring-substring-4);
-		if (name==NULL)
-			return rvG_OutOfMemory;
-		strncpy(name, substring+5, endsubstring-substring-5);
-		name[endsubstring-substring-5]='\0';
+		const std::string name{substring + 5,
+		                       static_cast<size_t>(endsubstring - substring - 5)};
 		m_ListOfFaces.SetLastFaceName(name);
 	}
 

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -583,8 +583,7 @@ GReturnValue CJavaView::ReadF()
 	double number;
 	char *word;
 
-	if (!m_ListOfFaces.AddNewFace())
-		return rvG_OutOfMemory;
+	m_ListOfFaces.AddNewFace();
 
 	char* substring=strstr(m_sParams, "name=");
 	if(substring!=NULL)

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -11,91 +11,55 @@
 
 CListOfFaces::CListOfFaces()
 {
-	m_pFirstFace = NULL;
-	m_pLastFace = NULL;
+	m_iCurrentFace = 0;
 }
-
-CListOfFaces::~CListOfFaces()
-{
-	DeleteAll();
-}
-
 
 void CListOfFaces::DeleteAll()
 {
-	CFace *pFace, *pF;
-
-	pFace=m_pFirstFace;
-
-	while(pFace!=NULL)
-	{
-		pF = pFace->m_pNextFace;
-		delete pFace;
-		pFace = pF;
-	}
-	m_pFirstFace = NULL;
-	m_pLastFace = NULL;
+	m_iCurrentFace = 0;
+	m_vFaces.clear();
 }
-
-
 
 void CListOfFaces::SetGeometryIndex(unsigned int uIndex)
 {
 	m_iGeometry = uIndex;
 }
 
-
 bool CListOfFaces::AddNewFace()
 {
-	CFace *pFace;
+	CFace pFace;
 
-	pFace = new CFace;
-	if (pFace == NULL) 
-		return false;
+	pFace.r = 0;
+	pFace.g = 0;
+	pFace.b = 0;
 
-	pFace->m_pNextFace = NULL;
-	pFace->name = "";
-	pFace->r=0;
-	pFace->g=0;
-	pFace->b=0;
-
-	if(m_pFirstFace==NULL)
-		m_pFirstFace=pFace;
-	else
-		m_pLastFace->m_pNextFace = pFace;
-	
-	m_pLastFace = pFace;
+	m_vFaces.push_back(pFace);
 
 	return true;
 }
 
 void CListOfFaces::AddNewVertex(int uIndex)
 {
-	m_pLastFace->AddNewVertex(uIndex);
+	m_vFaces.back().AddNewVertex(uIndex);
 }
-
 
 void CListOfFaces::AttachColorsToCurrentFace(unsigned char r,unsigned char g,unsigned char b)
 {
-	m_pCurrentFace->AttachColors(r,g,b);
+	m_vFaces[m_iCurrentFace].AttachColors(r, g, b);
 }
-
-
-
 
 CFace* CListOfFaces::GetFirstFace()
 {
-	m_pCurrentFace = m_pFirstFace;
-	return m_pCurrentFace;
+	m_iCurrentFace = 0;
+	return m_vFaces.empty() ? nullptr : &m_vFaces.front();
 }
-
 
 CFace* CListOfFaces::GetNextFace()
 {
-	if (m_pCurrentFace!=NULL)
+	if (m_iCurrentFace + 1 < m_vFaces.size())
 	{
-		m_pCurrentFace = m_pCurrentFace->m_pNextFace;
-		return m_pCurrentFace;
+		++m_iCurrentFace;
+		return &m_vFaces[m_iCurrentFace];
 	}
 	else
 		return NULL;
@@ -103,9 +67,8 @@ CFace* CListOfFaces::GetNextFace()
 
 void CListOfFaces::SetLastFaceName(const std::string &sName)
 {
-	m_pLastFace->name = sName;
+	m_vFaces.back().name = sName;
 }
-
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -3,7 +3,6 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "ListOfFaces.h"
-#include <malloc.h>
 #include <string>
 
 //////////////////////////////////////////////////////////////////////
@@ -31,8 +30,6 @@ void CListOfFaces::DeleteAll()
 	while(pFace!=NULL)
 	{
 		pF = pFace->m_pNextFace;
-		if(pFace->name!=NULL)
-			free(pFace->name);
 		delete pFace;
 		pFace = pF;
 	}
@@ -57,7 +54,7 @@ bool CListOfFaces::AddNewFace()
 		return false;
 
 	pFace->m_pNextFace = NULL;
-	pFace->name=NULL;
+	pFace->name = "";
 	pFace->r=0;
 	pFace->g=0;
 	pFace->b=0;
@@ -104,8 +101,7 @@ CFace* CListOfFaces::GetNextFace()
 		return NULL;
 }
 
-
-void CListOfFaces::SetLastFaceName(char* sName)
+void CListOfFaces::SetLastFaceName(const std::string &sName)
 {
 	m_pLastFace->name = sName;
 }

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -160,6 +160,7 @@ CListOfPoints::~CListOfPoints()
 }
 
 void CListOfPoints::DeleteAll() {
+	m_iCurrentPoint = 0;
 	m_vPoints.clear();
 }
 

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -154,11 +154,6 @@ CListOfPoints::CListOfPoints()
 	m_iCurrentPoint = 0;
 }
 
-CListOfPoints::~CListOfPoints()
-{
-	DeleteAll();
-}
-
 void CListOfPoints::DeleteAll() {
 	m_iCurrentPoint = 0;
 	m_vPoints.clear();

--- a/source/Tools/jv2gcl/ListOfFaces.cpp
+++ b/source/Tools/jv2gcl/ListOfFaces.cpp
@@ -25,7 +25,7 @@ void CListOfFaces::SetGeometryIndex(unsigned int uIndex)
 	m_iGeometry = uIndex;
 }
 
-bool CListOfFaces::AddNewFace()
+void CListOfFaces::AddNewFace()
 {
 	CFace pFace;
 
@@ -34,8 +34,6 @@ bool CListOfFaces::AddNewFace()
 	pFace.b = 0;
 
 	m_vFaces.push_back(pFace);
-
-	return true;
 }
 
 void CListOfFaces::AddNewVertex(int uIndex)

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -38,7 +38,7 @@ friend class CListOfFaces;
 public:
 	CFace();
 	void AddNewVertex(int uIndex);
-	unsigned char GetRColor() { return r; };
+	unsigned char GetRColor() { return r; }
 	unsigned char GetGColor() { return g; }
 	unsigned char GetBColor() { return b; }
 

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -60,7 +60,7 @@ public:
 	CListOfFaces();
 	void DeleteAll();
 	void SetGeometryIndex(unsigned int uIndex);
-	bool AddNewFace();
+	void AddNewFace();
 	void AddNewVertex(int uIndex);
 	CFace* GetFirstFace();
 	CFace* GetNextFace();

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -9,15 +9,6 @@
 #include <string>
 #include <vector>
 
-struct javaviewface
-{
-	int geometry;
-	int v1,v2,v3,v4;
-	unsigned char r,g,b;
-	bool visible;
-};
-
-
 struct vertex
 {
 	int index;

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -84,7 +84,6 @@ class CListOfPoints
 {
 public:
 	CListOfPoints();
-	virtual ~CListOfPoints();
 	void DeleteAll();
 	bool AddNewPoint(double x,double y,unsigned char r,unsigned char g,unsigned char b);
 	struct point* GetFirstPoint();

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -52,16 +52,12 @@ private:
 	bool m_bVisible;
 	std::vector<vertex> m_vVertices;
 	size_t m_iCurrentVertex;
-	CFace* m_pNextFace;
 };
-
-
 
 class CListOfFaces  
 {
 public:
 	CListOfFaces();
-	virtual ~CListOfFaces();
 	void DeleteAll();
 	void SetGeometryIndex(unsigned int uIndex);
 	bool AddNewFace();
@@ -74,11 +70,9 @@ public:
 
 private:
 	int m_iGeometry;
-	CFace *m_pFirstFace, *m_pCurrentFace, *m_pLastFace;
+	std::vector<CFace> m_vFaces;
+	size_t m_iCurrentFace;
 };
-
-
-
 
 class CListOfPoints
 {

--- a/source/Tools/jv2gcl/ListOfFaces.h
+++ b/source/Tools/jv2gcl/ListOfFaces.h
@@ -45,7 +45,7 @@ public:
 	struct vertex* GetFirstVertex();
 	struct vertex* GetNextVertex();
 	void AttachColors(unsigned char r0,unsigned char g0,unsigned char b0) { r = r0; b=b0; g=g0; }
-	char *name;
+	std::string name;
 private:
 	unsigned char r,g,b;
 
@@ -70,7 +70,7 @@ public:
 	CFace* GetNextFace();
 	int GetGeometry() { return m_iGeometry; }
 	void AttachColorsToCurrentFace(unsigned char r,unsigned char g,unsigned char b);
-	void SetLastFaceName(char* sName);
+	void SetLastFaceName(const std::string &sName);
 
 private:
 	int m_iGeometry;


### PR DESCRIPTION
This removes another source of C-style casts and simplifies surrounding code. The PR also includes some follow on simplification that I noticed while in the area.