### PR TITLE
manage 'CGCLCProverExpression' lists as vectors

### DIFF
--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -2530,7 +2530,7 @@ bool CAlgMethod::_RationalizeConjecture(CGCLCProverExpression *conjecture) {
   CGCLCProverExpression exprToRationalize;
   CGCLCProverExpression eNum, eDen;
   CGCLCProverExpression *eA, *eB, *eC, *eD;
-  GCLCexperssion_type diffType;
+  GCLCexpression_type diffType;
   Line *l;
   bool foundRational = false;
   bool rationalized = false;

--- a/source/TheoremProver/ProverExpression.cpp
+++ b/source/TheoremProver/ProverExpression.cpp
@@ -2,6 +2,8 @@
 #include "TheoremProver.h"
 #include <assert.h>
 #include <cmath>
+#include <cstddef>
+#include <vector>
 
 #define EPSILON 0.00001
 
@@ -1086,42 +1088,31 @@ bool CGCLCProverExpression::SumOfFractions() {
 
 bool CGCLCProverExpression::CancelationMult(
     const CGCLCProverExpression &Factor) {
-  CGCLCProverExpression **aSummands, **aMultiplicants;
 
   int iMaxIndex = CountTopLevelOperands(ep_sum);
-  aSummands = new CGCLCProverExpression *[iMaxIndex];
+  std::vector<CGCLCProverExpression *> aSummands;
+  aSummands.reserve(iMaxIndex);
 
-  iMaxIndex = 0;
-  FillTopLevelOperands(ep_sum, aSummands, iMaxIndex);
+  FillTopLevelOperands(ep_sum, aSummands);
 
-  int j, k;
+  for (CGCLCProverExpression *j : aSummands) {
+    std::vector<CGCLCProverExpression *> aMultiplicants;
+    aMultiplicants.reserve(j->CountTopLevelOperands(ep_mult));
 
-  for (j = 0; j < iMaxIndex; j++) {
-    aMultiplicants = new CGCLCProverExpression
-        *[aSummands[j]->CountTopLevelOperands(ep_mult)];
-    if (aMultiplicants == NULL) {
-      delete[] aSummands;
-      return false;
-    }
+    j->FillTopLevelOperands(ep_mult, aMultiplicants);
 
-    int iMaxIndex2 = 0;
-    aSummands[j]->FillTopLevelOperands(ep_mult, aMultiplicants, iMaxIndex2);
+    for (CGCLCProverExpression *k : aMultiplicants) {
+      if (Factor == *k) {
+        *k = 1.0;
 
-    bool bExists = false;
-    for (k = 0; k < iMaxIndex2 && !bExists; k++) {
-      if (Factor == *(aMultiplicants[k])) {
-        *aMultiplicants[k] = 1.0;
-
-        bExists = true;
+        break;
       } else {
-        if (aMultiplicants[k]->GetType() == ep_number)
-          if (aMultiplicants[k]->GetNumber() == 0)
-            bExists = true;
+        if (k->GetType() == ep_number)
+          if (k->GetNumber() == 0)
+            break;
       }
     }
-    delete[] aMultiplicants;
   }
-  delete[] aSummands;
   return true;
 }
 
@@ -1129,45 +1120,38 @@ bool CGCLCProverExpression::CancelationMult(
 
 bool CGCLCProverExpression::AllSummandsHaveFactor(
     const CGCLCProverExpression &Factor) {
-  CGCLCProverExpression **aSummands;
-  CGCLCProverExpression **aMultiplicants;
 
   int iMaxIndex = CountTopLevelOperands(ep_sum);
 
-  aSummands = new CGCLCProverExpression *[iMaxIndex];
+  std::vector<CGCLCProverExpression *> aSummands;
+  aSummands.reserve(iMaxIndex);
 
-  iMaxIndex = 0;
-  FillTopLevelOperands(ep_sum, aSummands, iMaxIndex);
+  FillTopLevelOperands(ep_sum, aSummands);
 
   bool bEverywhere, bExists;
-  int j, k;
 
   bEverywhere = true;
-  for (j = 0; j < iMaxIndex && bEverywhere; j++) {
-    if (aSummands[j]->GetType() != ep_number ||
-        aSummands[j]->GetNumber() != 0) {
-      aMultiplicants = new CGCLCProverExpression
-          *[aSummands[j]->CountTopLevelOperands(ep_mult)];
-      if (aMultiplicants == NULL) {
-        delete[] aSummands;
-        return false;
-      }
+  for (CGCLCProverExpression *j : aSummands) {
+    if (j->GetType() != ep_number || j->GetNumber() != 0) {
+      std::vector<CGCLCProverExpression *> aMultiplicants;
+      aMultiplicants.reserve(j->CountTopLevelOperands(ep_mult));
 
-      int iMaxIndex2 = 0;
-      aSummands[j]->FillTopLevelOperands(ep_mult, aMultiplicants, iMaxIndex2);
+      j->FillTopLevelOperands(ep_mult, aMultiplicants);
 
       bExists = false;
 
-      for (k = 0; k < iMaxIndex2 && !bExists; k++) {
-        if (Factor == *(aMultiplicants[k]))
+      for (CGCLCProverExpression *k : aMultiplicants) {
+        if (Factor == *k) {
           bExists = true;
+          break;
+        }
       }
-      if (!bExists)
+      if (!bExists) {
         bEverywhere = false;
-      delete[] aMultiplicants;
+        break;
+      }
     }
   }
-  delete[] aSummands;
   return bEverywhere;
 }
 
@@ -1181,59 +1165,41 @@ bool CGCLCProverExpression::SimilarSummandsOnTwoSides() {
   if (GetArg(1).type == ep_number)
     return false;
 
-  CGCLCProverExpression **aSummands1, **aSummands2;
-
   int iMaxIndex1 = GetArg(0).CountTopLevelOperands(ep_sum);
   int iMaxIndex2 = GetArg(1).CountTopLevelOperands(ep_sum);
 
-  aSummands1 = new CGCLCProverExpression *[iMaxIndex1];
-  iMaxIndex1 = 0;
-  GetArg(0).FillTopLevelOperands(ep_sum, aSummands1, iMaxIndex1);
+  std::vector<CGCLCProverExpression *> aSummands1;
+  aSummands1.reserve(iMaxIndex1);
+  GetArg(0).FillTopLevelOperands(ep_sum, aSummands1);
 
-  aSummands2 = new CGCLCProverExpression *[iMaxIndex2];
-  iMaxIndex2 = 0;
-  GetArg(1).FillTopLevelOperands(ep_sum, aSummands2, iMaxIndex2);
+  std::vector<CGCLCProverExpression *> aSummands2;
+  aSummands2.reserve(iMaxIndex2);
+  GetArg(1).FillTopLevelOperands(ep_sum, aSummands2);
 
-  int i, j, k, l;
-  for (i = 0; i < iMaxIndex1; i++) {
+  for (CGCLCProverExpression *i : aSummands1) {
 
-    CGCLCProverExpression **aMultiplicants1, **aMultiplicants2;
-    aMultiplicants1 = new CGCLCProverExpression
-        *[aSummands1[i]->CountTopLevelOperands(ep_mult)];
-    if (aMultiplicants1 == NULL) {
-      delete[] aSummands1;
-      delete[] aSummands2;
-      return false;
-    }
+    std::vector<CGCLCProverExpression *> aMultiplicants1;
+    aMultiplicants1.reserve(i->CountTopLevelOperands(ep_mult));
 
-    int iMaxIndex3 = 0;
-    aSummands1[i]->FillTopLevelOperands(ep_mult, aMultiplicants1, iMaxIndex3);
+    i->FillTopLevelOperands(ep_mult, aMultiplicants1);
 
-    for (j = 0; j < iMaxIndex2; j++) {
-      aMultiplicants2 = new CGCLCProverExpression
-          *[aSummands2[j]->CountTopLevelOperands(ep_mult)];
-      if (aMultiplicants2 == NULL) {
-        delete[] aMultiplicants1;
-        delete[] aSummands1;
-        delete[] aSummands2;
-        return false;
-      }
+    for (CGCLCProverExpression *j : aSummands2) {
+      std::vector<CGCLCProverExpression *> aMultiplicants2;
+      aMultiplicants2.reserve(j->CountTopLevelOperands(ep_mult));
 
-      int iMaxIndex4 = 0;
-      aSummands2[j]->FillTopLevelOperands(ep_mult, aMultiplicants2, iMaxIndex4);
+      j->FillTopLevelOperands(ep_mult, aMultiplicants2);
 
-      int k0 = (aMultiplicants1[0]->type == ep_number ? 1 : 0);
-      int l0 = (aMultiplicants2[0]->type == ep_number ? 1 : 0);
+      const size_t k0 = aMultiplicants1[0]->type == ep_number ? 1 : 0;
+      const size_t l0 = aMultiplicants2[0]->type == ep_number ? 1 : 0;
 
-      if ((iMaxIndex3 - k0) != (iMaxIndex4 - l0)) {
-        delete[] aMultiplicants2;
+      if (aMultiplicants1.size() - k0 != aMultiplicants2.size() - l0) {
         continue;
       }
 
       bool bAllFound = true;
-      for (k = k0; k < iMaxIndex3 && bAllFound; k++) {
+      for (size_t k = k0; k < aMultiplicants1.size() && bAllFound; k++) {
         bool bFoundMatching = false;
-        for (l = l0; l < iMaxIndex4 && !bFoundMatching; l++)
+        for (size_t l = l0; l < aMultiplicants2.size() && !bFoundMatching; l++)
           if (aMultiplicants2[l] != NULL)
             if (*(aMultiplicants1[k]) == *(aMultiplicants2[l])) {
               bFoundMatching = true;
@@ -1258,26 +1224,18 @@ bool CGCLCProverExpression::SimilarSummandsOnTwoSides() {
           else
             n = 1 - aMultiplicants2[0]->nNumber;
 
-          CGCLCProverExpression a(*(aSummands1[i]));
+          CGCLCProverExpression a(*i);
           CGCLCProverExpression b(n);
-          *aSummands1[i] = (b * a);
+          *i = b * a;
         }
 
-        *aSummands2[j] = 0.0;
+        *j = 0.0;
 
-        delete[] aMultiplicants1;
-        delete[] aMultiplicants2;
-        delete[] aSummands1;
-        delete[] aSummands2;
         return true;
-      } else
-        delete[] aMultiplicants2;
+      }
     }
-    delete[] aMultiplicants1;
   }
 
-  delete[] aSummands1;
-  delete[] aSummands2;
   return false;
 }
 
@@ -1287,57 +1245,39 @@ bool CGCLCProverExpression::SimilarSummands() {
   if (type != ep_sum)
     return false;
 
-  CGCLCProverExpression **aSummands;
-
   int iMaxIndex = CountTopLevelOperands(ep_sum);
   if (iMaxIndex == 1)
     return false;
 
-  aSummands = new CGCLCProverExpression *[iMaxIndex];
-  if (aSummands == NULL)
-    return false;
+  std::vector<CGCLCProverExpression *> aSummands;
+  aSummands.reserve(iMaxIndex);
 
-  iMaxIndex = 0;
-  FillTopLevelOperands(ep_sum, aSummands, iMaxIndex);
+  FillTopLevelOperands(ep_sum, aSummands);
 
-  int i, j, k, l;
-  for (i = 0; i < iMaxIndex; i++) {
+  for (size_t i = 0; i < aSummands.size(); i++) {
 
-    CGCLCProverExpression **aMultiplicants1, **aMultiplicants2;
-    aMultiplicants1 = new CGCLCProverExpression
-        *[aSummands[i]->CountTopLevelOperands(ep_mult)];
-    if (aMultiplicants1 == NULL) {
-      delete[] aSummands;
-      return false;
-    }
+    std::vector<CGCLCProverExpression *> aMultiplicants1;
+    aMultiplicants1.reserve(aSummands[i]->CountTopLevelOperands(ep_mult));
 
-    int iMaxIndex1 = 0;
-    aSummands[i]->FillTopLevelOperands(ep_mult, aMultiplicants1, iMaxIndex1);
+    aSummands[i]->FillTopLevelOperands(ep_mult, aMultiplicants1);
 
-    for (j = i + 1; j < iMaxIndex; j++) {
-      aMultiplicants2 = new CGCLCProverExpression
-          *[aSummands[j]->CountTopLevelOperands(ep_mult)];
-      if (aMultiplicants2 == NULL) {
-        delete[] aMultiplicants1;
-        delete[] aSummands;
-        return false;
-      }
+    for (size_t j = i + 1; j < aSummands.size(); j++) {
+      std::vector<CGCLCProverExpression *> aMultiplicants2;
+      aMultiplicants2.reserve(aSummands[j]->CountTopLevelOperands(ep_mult));
 
-      int iMaxIndex2 = 0;
-      aSummands[j]->FillTopLevelOperands(ep_mult, aMultiplicants2, iMaxIndex2);
+      aSummands[j]->FillTopLevelOperands(ep_mult, aMultiplicants2);
 
-      int k0 = (aMultiplicants1[0]->type == ep_number ? 1 : 0);
-      int l0 = (aMultiplicants2[0]->type == ep_number ? 1 : 0);
+      const size_t k0 = aMultiplicants1[0]->type == ep_number ? 1 : 0;
+      const size_t l0 = aMultiplicants2[0]->type == ep_number ? 1 : 0;
 
-      if ((iMaxIndex1 - k0) != (iMaxIndex2 - l0)) {
-        delete[] aMultiplicants2;
+      if (aMultiplicants1.size() - k0 != aMultiplicants2.size() - l0) {
         continue;
       }
 
       bool bAllFound = true;
-      for (k = k0; k < iMaxIndex1 && bAllFound; k++) {
+      for (size_t k = k0; k < aMultiplicants1.size() && bAllFound; k++) {
         bool bFoundMatching = false;
-        for (l = l0; l < iMaxIndex2 && !bFoundMatching; l++)
+        for (size_t l = l0; l < aMultiplicants2.size() && !bFoundMatching; l++)
           if (aMultiplicants2[l] != NULL)
             if (*(aMultiplicants1[k]) == *(aMultiplicants2[l])) {
               bFoundMatching = true;
@@ -1370,17 +1310,11 @@ bool CGCLCProverExpression::SimilarSummands() {
 
         *aSummands[j] = 0.0;
 
-        delete[] aMultiplicants1;
-        delete[] aMultiplicants2;
-        delete[] aSummands;
         return true;
-      } else
-        delete[] aMultiplicants2;
+      }
     }
-    delete[] aMultiplicants1;
   }
 
-  delete[] aSummands;
   return false;
 }
 
@@ -1397,13 +1331,12 @@ int CGCLCProverExpression::CountTopLevelOperands(GCLCexperssion_type t) {
 // --------------------------------------------------------------------------
 
 void CGCLCProverExpression::FillTopLevelOperands(GCLCexperssion_type t,
-                                                 CGCLCProverExpression **a,
-                                                 int &iIndex) {
+                                                 std::vector<CGCLCProverExpression *> &a) {
   if (type != t)
-    a[iIndex++] = this;
+    a.push_back(this);
   else {
-    GetArg(0).FillTopLevelOperands(t, a, iIndex);
-    GetArg(1).FillTopLevelOperands(t, a, iIndex);
+    GetArg(0).FillTopLevelOperands(t, a);
+    GetArg(1).FillTopLevelOperands(t, a);
   }
 }
 

--- a/source/TheoremProver/ProverExpression.cpp
+++ b/source/TheoremProver/ProverExpression.cpp
@@ -13,7 +13,7 @@ using namespace std;
 
 Rules CGCLCProverExpression::mRules;
 
-unsigned arity(enum GCLCexperssion_type type) {
+unsigned arity(enum GCLCexpression_type type) {
   switch (type) {
   case ep_number:
   case ep_point:
@@ -119,7 +119,7 @@ CGCLCProverExpression &CGCLCProverExpression::operator=(const double n) {
 
 // --------------------------------------------------------------------------
 
-CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
+CGCLCProverExpression::CGCLCProverExpression(GCLCexpression_type t,
                                              const std::string &a) {
   assert(t == ep_point || t == ep_constant);
   type = t;
@@ -132,7 +132,7 @@ CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
 
 // --------------------------------------------------------------------------
 
-CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
+CGCLCProverExpression::CGCLCProverExpression(GCLCexpression_type t,
                                              const std::string &a0,
                                              const std::string &a1) {
   assert(t == ep_segment || t == ep_diffx || t == ep_diffy);
@@ -147,7 +147,7 @@ CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
 
 // --------------------------------------------------------------------------
 
-CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
+CGCLCProverExpression::CGCLCProverExpression(GCLCexpression_type t,
                                              const std::string &a0, const std::string &a1,
                                              const std::string &a2) {
   assert(t == ep_s3 || t == ep_p3);
@@ -162,7 +162,7 @@ CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
 
 // --------------------------------------------------------------------------
 
-CGCLCProverExpression::CGCLCProverExpression(GCLCexperssion_type t,
+CGCLCProverExpression::CGCLCProverExpression(GCLCexpression_type t,
                                              const std::string &a0, const std::string &a1,
                                              const std::string &a2,
                                              const std::string &a3) {
@@ -189,7 +189,7 @@ CGCLCProverExpression::CGCLCProverExpression(const double n) {
 // --------------------------------------------------------------------------
 
 CGCLCProverExpression::CGCLCProverExpression(
-    GCLCexperssion_type t, const CGCLCProverExpression &arg0,
+    GCLCexpression_type t, const CGCLCProverExpression &arg0,
     const CGCLCProverExpression &arg1) {
   assert(arity(t) == 2);
   type = t;
@@ -328,7 +328,7 @@ void CGCLCProverExpression::Pop(CGCLCProverExpression &left,
 
 // --------------------------------------------------------------------------
 
-void CGCLCProverExpression::Set(GCLCexperssion_type t,
+void CGCLCProverExpression::Set(GCLCexpression_type t,
                                 const CGCLCProverExpression &arg0,
                                 const CGCLCProverExpression &arg1) {
   assert(arity(t) == 2);
@@ -1320,7 +1320,7 @@ bool CGCLCProverExpression::SimilarSummands() {
 
 // --------------------------------------------------------------------------
 
-int CGCLCProverExpression::CountTopLevelOperands(GCLCexperssion_type t) {
+int CGCLCProverExpression::CountTopLevelOperands(GCLCexpression_type t) {
   if (type != t)
     return 1;
   else
@@ -1330,7 +1330,7 @@ int CGCLCProverExpression::CountTopLevelOperands(GCLCexperssion_type t) {
 
 // --------------------------------------------------------------------------
 
-void CGCLCProverExpression::FillTopLevelOperands(GCLCexperssion_type t,
+void CGCLCProverExpression::FillTopLevelOperands(GCLCexpression_type t,
                                                  std::vector<CGCLCProverExpression *> &a) {
   if (type != t)
     a.push_back(this);
@@ -1431,7 +1431,7 @@ bool CTheoremProver::GetPointCoordinates(const std::string &sPoint, double &x,
 
 // --------------------------------------------------------------------------
 
-void CGCLCProverExpression::SetType(GCLCexperssion_type t) { type = t; }
+void CGCLCProverExpression::SetType(GCLCexpression_type t) { type = t; }
 
 // --------------------------------------------------------------------------
 

--- a/source/TheoremProver/ProverExpression.h
+++ b/source/TheoremProver/ProverExpression.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-enum GCLCexperssion_type {
+enum GCLCexpression_type {
   ep_point,
   ep_number,
   ep_constant,
@@ -123,12 +123,12 @@ class CGCLCProverExpression {
 public:
   CGCLCProverExpression();
   CGCLCProverExpression(const CGCLCProverExpression &r);
-  CGCLCProverExpression(GCLCexperssion_type t, const std::string &arg);
-  CGCLCProverExpression(GCLCexperssion_type t, const std::string &a0,
+  CGCLCProverExpression(GCLCexpression_type t, const std::string &arg);
+  CGCLCProverExpression(GCLCexpression_type t, const std::string &a0,
                         const std::string &a1);
-  CGCLCProverExpression(GCLCexperssion_type t, const std::string &a0,
+  CGCLCProverExpression(GCLCexpression_type t, const std::string &a0,
                         const std::string &a1, const std::string &a2);
-  CGCLCProverExpression(GCLCexperssion_type t, const std::string &a0,
+  CGCLCProverExpression(GCLCexpression_type t, const std::string &a0,
                         const std::string &a1, const std::string &a2, const std::string &a3);
   CGCLCProverExpression(const double n);
 
@@ -137,7 +137,7 @@ public:
 
   CGCLCProverExpression &operator=(const CGCLCProverExpression &r);
   CGCLCProverExpression &operator=(const double n);
-  CGCLCProverExpression(GCLCexperssion_type t,
+  CGCLCProverExpression(GCLCexpression_type t,
                         const CGCLCProverExpression &arg0,
                         const CGCLCProverExpression &arg1);
 
@@ -157,10 +157,10 @@ public:
   CGCLCProverExpression operator+(const CGCLCProverExpression &a);
   CGCLCProverExpression operator/(const CGCLCProverExpression &a);
 
-  void Set(GCLCexperssion_type t, const CGCLCProverExpression &arg0,
+  void Set(GCLCexpression_type t, const CGCLCProverExpression &arg0,
            const CGCLCProverExpression &arg1);
-  void SetType(GCLCexperssion_type t);
-  GCLCexperssion_type GetType() const { return type; }
+  void SetType(GCLCexpression_type t);
+  GCLCexpression_type GetType() const { return type; }
 
   double GetNumber() const { return nNumber; }
 
@@ -196,8 +196,8 @@ public:
   bool Replace(const CGCLCProverExpression &LHS,
                const CGCLCProverExpression &RHS);
 
-  int CountTopLevelOperands(GCLCexperssion_type t);
-  void FillTopLevelOperands(GCLCexperssion_type t,
+  int CountTopLevelOperands(GCLCexpression_type t);
+  void FillTopLevelOperands(GCLCexpression_type t,
                             std::vector<CGCLCProverExpression *> &a);
   bool CancelationMult(const CGCLCProverExpression &Factor);
   bool AllSummandsHaveFactor(const CGCLCProverExpression &Factor);
@@ -211,7 +211,7 @@ public:
                       CGCLCProverExpression *&parent, int &index) const;
 
 private:
-  GCLCexperssion_type type;
+  GCLCexpression_type type;
   CGCLCProverExpression *arg[ExpressionArgCount];
 
   std::string sName;
@@ -247,6 +247,6 @@ private:
   unsigned id;
 };
 
-unsigned arity(enum GCLCexperssion_type type);
+unsigned arity(enum GCLCexpression_type type);
 
 #endif // !defined(prover_expression_h)

--- a/source/TheoremProver/ProverExpression.h
+++ b/source/TheoremProver/ProverExpression.h
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 enum GCLCexperssion_type {
   ep_point,
@@ -196,8 +197,8 @@ public:
                const CGCLCProverExpression &RHS);
 
   int CountTopLevelOperands(GCLCexperssion_type t);
-  void FillTopLevelOperands(GCLCexperssion_type t, CGCLCProverExpression **a,
-                            int &iIndex);
+  void FillTopLevelOperands(GCLCexperssion_type t,
+                            std::vector<CGCLCProverExpression *> &a);
   bool CancelationMult(const CGCLCProverExpression &Factor);
   bool AllSummandsHaveFactor(const CGCLCProverExpression &Factor);
 

--- a/source/TheoremProver/TheoremProver.cpp
+++ b/source/TheoremProver/TheoremProver.cpp
@@ -348,7 +348,7 @@ void CTheoremProver::PrintNDGConditions(bool itemize) {
 
 // ----------------------------------------------------------------------------
 
-bool CTheoremProver::AddNDG(GCLCexperssion_type type,
+bool CTheoremProver::AddNDG(GCLCexpression_type type,
                             const CGCLCProverExpression &Left,
                             const CGCLCProverExpression &Right,
                             const std::string &sCond) {

--- a/source/TheoremProver/TheoremProver.h
+++ b/source/TheoremProver/TheoremProver.h
@@ -88,7 +88,7 @@ private:
   std::string m_sCondition;
   CGCLCProverExpression m_Left;
   CGCLCProverExpression m_Right;
-  GCLCexperssion_type m_type;
+  GCLCexpression_type m_type;
 };
 
 class CNewDef {
@@ -149,7 +149,7 @@ protected:
   bool OnTheLine(const std::string &P, const std::string &l);
 
   bool AddNewDef(std::string &sDef);
-  bool AddNDG(GCLCexperssion_type type, const CGCLCProverExpression &Left,
+  bool AddNDG(GCLCexpression_type type, const CGCLCProverExpression &Left,
               const CGCLCProverExpression &Right, const std::string &sCond);
 
   bool CalculateCoordinates(CGCLCProverCommand &Command) const;


### PR DESCRIPTION
This removes some manual memory management and fixes some minor memory leaks.