### PR TITLE
add 'install' targets to the build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,9 @@ jobs:
 
       - name: Make CLI and GUI version
         run: |
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
-          mkdir -p executable
-          cp build/gclc executable/
-          cp build/source/gclc-gui executable/
+          cmake --build build --target install
 
       - name: Upload executables
         uses: actions/upload-artifact@v4
@@ -119,11 +117,9 @@ jobs:
 
       - name: Make CLI and GUI version
         run: |
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
-          mkdir -p executable
-          cp build/gclc executable/
-          cp build/source/gclc-gui* executable/
+          cmake --build build --target install
 
       - name: Move DLLs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,9 @@ jobs:
 
       - name: Make CLI version
         run: |
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_INSTALL_DIR=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
-          mkdir -p executable
-          cp build/gclc executable/
+          cmake --build build --target install
 
       - name: Download latest GCLC release
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,4 +107,8 @@ if(MINGW)
   )
 endif()
 
+install(TARGETS gclc
+  RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
+)
+
 add_subdirectory(source)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -98,4 +98,8 @@ if(gui)
   target_link_libraries(gclc-gui
     PRIVATE Qt6::Core Qt6::Gui Qt6::PrintSupport Qt6::Widgets)
 
+  install(TARGETS gclc-gui
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
+  )
+
 endif()


### PR DESCRIPTION
These are a bit non-standard compared to the usual CMake pattern for this.
Typically one would `include(GNUInstallDirs)` and then use the variable
`$CMAKE_INSTALL_BINDIR` as the destination for executables. However the current
desire is to have them at the top level, as this will not be their final
destination.