### PR TITLE
CI: fix installation path used in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Make CLI version
         run: |
-          cmake -DCMAKE_INSTALL_DIR=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
           cmake --build build --target install
 


### PR DESCRIPTION
This was a typo in 6fcde12a93497a2efb86f6733ea1be74c4daf85b.

I am a little confused how #52 somehow passed…