### PR TITLE
default binary installation location to ./executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Make CLI and GUI version
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
           cmake --build build --target install
 
@@ -117,7 +117,7 @@ jobs:
 
       - name: Make CLI and GUI version
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
           cmake --build build --target install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Make CLI version
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX=executable -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build -S .
           cmake --build build
           cmake --build build --target install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(GCLC LANGUAGES CXX)
 set(gui AUTO CACHE STRING "build the GCLC GUI")
 set_property(CACHE gui PROPERTY STRINGS AUTO ON OFF)
 
+# default installation location to “executable/”
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/executable CACHE PATH
+    "installation prefix" FORCE)
+endif()
+
 # enable -W and -Wall if possible
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-W HAS_W)


### PR DESCRIPTION
As per email discussion. This is apparently the CMake-recommended way of
achieving this, https://cmake.org/pipermail/cmake/2010-December/041135.html.