### PR TITLE
reference count 'TermStorage' with 'std::shared_ptr'

### DIFF
--- a/source/AlgebraicMethods/Polynomial.cpp
+++ b/source/AlgebraicMethods/Polynomial.cpp
@@ -1,4 +1,5 @@
 #include "Polynomial.h"
+#include <memory>
 
 Polynomial::Polynomial()
 {
@@ -8,7 +9,6 @@ Polynomial::Polynomial()
 
 Polynomial::~Polynomial()
 {
-	_terms->Dispose();
 	DESTR("poly");
 }
 
@@ -66,11 +66,10 @@ int Polynomial::Mul(Polynomial* p)
 	}
 	if (p->IsZero())
 	{
-		_terms->Dispose();
 		_terms = Term::CreateTermStorage();
 	}
 
-	TermStorage* tmpTerms = Term::CreateTermStorage();
+	std::shared_ptr<TermStorage> tmpTerms = Term::CreateTermStorage();
 
 	uint cnt1 = this->GetTermCount();
 
@@ -91,7 +90,6 @@ int Polynomial::Mul(Polynomial* p)
 	}
 
 	// now replace term storages
-	_terms->Dispose();
 	_terms = tmpTerms;
 
 	return status;
@@ -123,7 +121,6 @@ int Polynomial::Mul(REAL r)
 	if (r == 0)
 	{
 		// reset polynomial
-		_terms->Dispose();
 		_terms = Term::CreateTermStorage();
 	}
 	else

--- a/source/AlgebraicMethods/Polynomial.h
+++ b/source/AlgebraicMethods/Polynomial.h
@@ -4,6 +4,7 @@
 #include "TermStorage.h"
 #include "ITimeout.h"
 #include <iostream>
+#include <memory>
 
 /*************************************************************
 *
@@ -23,7 +24,7 @@ protected:
 	// something else.
 	// Crucial for performance.
 	//
-	TermStorage* _terms;
+	std::shared_ptr<TermStorage> _terms;
 
 public:
 	Polynomial();

--- a/source/AlgebraicMethods/Term.cpp
+++ b/source/AlgebraicMethods/Term.cpp
@@ -3,6 +3,7 @@
 #include "TermStorageAvl.h"
 #include "TermStorageVector.h"
 #include "XTerm.h"
+#include <memory>
 
 Term::Term() {
 #if 0
@@ -49,11 +50,11 @@ void Term::Merge(Term * /* other */) {}
 
 TermKeyType Term::Key() { return this; }
 
-TermStorage *Term::CreateTermStorage() {
+std::shared_ptr<TermStorage> Term::CreateTermStorage() {
 #if TERM_STORAGE_CLASS_VECTOR
-  return new TermStorageVector();
+  return std::make_shared<TermStorageVector>();
 #elif TERM_STORAGE_CLASS_AVL_TREE
-  return new TermStorageAvlTree();
+  return std::make_shared<TermStorageAvlTree>();
 #endif
 }
 

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -3,6 +3,7 @@
 #include "Object.h"
 #include "Power.h"
 #include <iostream>
+#include <memory>
 
 class Term;
 class TermStorage;
@@ -50,7 +51,7 @@ public:
 	// key used by TermStorage
 	TermKeyType Key();
 
-	static TermStorage* CreateTermStorage();
+	static std::shared_ptr<TermStorage> CreateTermStorage();
 
 	// powers
 	uint GetPowerCount() const;

--- a/source/AlgebraicMethods/TermStorage.h
+++ b/source/AlgebraicMethods/TermStorage.h
@@ -10,7 +10,7 @@
 // its elements and quick addition of the new
 // element while keeping elements in sorted order
 //
-class TermStorage : public Object
+class TermStorage
 {
 public:
 

--- a/source/AlgebraicMethods/TermStorageAvl.cpp
+++ b/source/AlgebraicMethods/TermStorageAvl.cpp
@@ -445,16 +445,6 @@ void TermStorageAvlTree::Construct()
 	COSTR("reused avl tree");
 }
 
-void TermStorageAvlTree::Dispose()
-{
-	_refCount --;
-
-	if (_refCount == 0)
-	{
-		delete this;
-	}
-}
-
 int TermStorageAvlTree::AddTerm(Term* term)
 {
 	term->AddRef();

--- a/source/AlgebraicMethods/TermStorageAvl.cpp
+++ b/source/AlgebraicMethods/TermStorageAvl.cpp
@@ -5,12 +5,6 @@
 
 // ----------------------------------------------------------------------------- Definitions
 
-   // Return the maximum of two numbers
-inline static int
-MAX(int a, int b) {
-   return  (a > b) ? a : b;
-}
-
    // Use mnemonic constants for valid balance-factor values
 enum balance_t { LEFT_HEAVY = -1, BALANCED = 0, RIGHT_HEAVY = 1 };
 
@@ -126,7 +120,7 @@ AvlNode::RotateTwice(AvlNode * & root, dir_t dir)
    root->mySubtree[otherDir] = oldOtherDirSubtree;
 
       // update balances
-   root->mySubtree[LEFT]->myBal  = -MAX(root->myBal, 0);
+   root->mySubtree[LEFT]->myBal  = -std::max(int{root->myBal}, 0);
    root->mySubtree[RIGHT]->myBal = -std::min(int{root->myBal}, 0);
    root->myBal = 0;
 
@@ -382,7 +376,7 @@ int
 AvlNode::Height() const {
    int  leftHeight  = (mySubtree[LEFT])  ? mySubtree[LEFT]->Height()  : 0;
    int  rightHeight = (mySubtree[RIGHT]) ? mySubtree[RIGHT]->Height() : 0;
-   return  (1 + MAX(leftHeight, rightHeight));
+   return 1 + std::max(leftHeight, rightHeight);
 }
 
 

--- a/source/AlgebraicMethods/TermStorageAvl.cpp
+++ b/source/AlgebraicMethods/TermStorageAvl.cpp
@@ -1,14 +1,9 @@
 // <plaintext>
 #include "TermStorageAvl.h"
 #include "ITimeout.h"
+#include <algorithm>
 
 // ----------------------------------------------------------------------------- Definitions
-
-   // Return the minumum of two numbers
-inline static int
-MIN(int a, int b) {
-   return  (a < b) ? a : b;
-}
 
    // Return the maximum of two numbers
 inline static int
@@ -132,7 +127,7 @@ AvlNode::RotateTwice(AvlNode * & root, dir_t dir)
 
       // update balances
    root->mySubtree[LEFT]->myBal  = -MAX(root->myBal, 0);
-   root->mySubtree[RIGHT]->myBal = -MIN(root->myBal, 0);
+   root->mySubtree[RIGHT]->myBal = -std::min(int{root->myBal}, 0);
    root->myBal = 0;
 
       // A double rotation always shortens the overall height of the tree

--- a/source/AlgebraicMethods/TermStorageAvl.h
+++ b/source/AlgebraicMethods/TermStorageAvl.h
@@ -208,7 +208,6 @@ public:
 	   DESTR("avl tree");
    }
    void Construct();
-   void Dispose();
 
    // See if the tree is empty
    int

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -2,6 +2,7 @@
 #include "XPolynomial.h"
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <new>
 #include <sstream>
 #include <string>
@@ -181,7 +182,7 @@ void XPolynomial::SPol(XPolynomial *xp) {
   // multiply with -1
   s2c1->Inverse();
 
-  TermStorage *tmpTerms = Term::CreateTermStorage();
+  std::shared_ptr<TermStorage> tmpTerms = Term::CreateTermStorage();
 
   // c2 * s1 * f1
   uint size = this->GetTermCount();
@@ -205,7 +206,6 @@ void XPolynomial::SPol(XPolynomial *xp) {
   s2c1->Dispose();
 
   // now replace term storages
-  _terms->Dispose();
   _terms = tmpTerms;
 }
 


### PR DESCRIPTION
This avoids the need for manual `Dispose` calls, removing an opportunity for
accidental omissions. By leaning on the standard library, we also get a
reference counting implementation optimised for the target platform.

If these changes look reasonable, we could look at replacing the other uses of the `Object` mechanism with `shared_ptr` too.