### PR TITLE
manage 'CGCLCProverExpression::arg' pointers as smart pointers

### DIFF
--- a/source/TheoremProver/ProverExpression.h
+++ b/source/TheoremProver/ProverExpression.h
@@ -1,6 +1,7 @@
 #if !defined(prover_expression_h)
 #define prover_expression_h
 
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -171,7 +172,7 @@ public:
   void SetArg(unsigned i, const CGCLCProverExpression &a);
   void SetArgName(unsigned i, const std::string &s);
   CGCLCProverExpression &GetArg(int i) const { return *arg[i]; }
-  CGCLCProverExpression *GetArgP(int i) const { return arg[i]; }
+  CGCLCProverExpression *GetArgP(int i) const { return arg[i].get(); }
   std::string GetArgName(unsigned i) const;
 
   bool operator==(const CGCLCProverExpression &r) const;
@@ -212,7 +213,7 @@ public:
 
 private:
   GCLCexpression_type type;
-  CGCLCProverExpression *arg[ExpressionArgCount];
+  std::unique_ptr<CGCLCProverExpression> arg[ExpressionArgCount];
 
   std::string sName;
   double nNumber;

--- a/source/Tools/jv2gcl/JavaView.cpp
+++ b/source/Tools/jv2gcl/JavaView.cpp
@@ -437,9 +437,9 @@ GReturnValue CJavaView::ReadFaceSet()
 					(pFace->GetBColor()==0)))
 				{
 					sprintf(m_sOutput,"color %i %i %i",
-						(int)((unsigned char)pFace->GetRColor()),
-						(int)((unsigned char)pFace->GetGColor()), 
-						(int)((unsigned char)pFace->GetBColor()));
+						(int)pFace->GetRColor(),
+						(int)pFace->GetGColor(),
+						(int)pFace->GetBColor());
 					Output(m_sOutput);
 				}
 				


### PR DESCRIPTION
This removes a chance for missing `delete` calls.