### PR TITLE
fix typo in WASM code

### DIFF
--- a/source/wGCLCmain.cpp
+++ b/source/wGCLCmain.cpp
@@ -69,7 +69,7 @@ EXTERN EMSCRIPTEN_KEEPALIVE void render(char *input, char *fileName,
   if (r == rvG_OK) {
     std::unique_ptr<CGCLCOutput> pO;
     if (outputType == eSVGoutput)
-      pO.reset(CSVGOutput(outputStream));
+      pO.reset(new CSVGOutput(outputStream));
     else if (outputType == eEPSoutput)
       pO.reset(new CEPSOutput(outputStream));
     else if (outputType == eLaTeXoutput)


### PR DESCRIPTION
This was a mistake in 5e6178cb618c28c947151c4462f22306fa113bd3.