### PR TITLE
squash compiler warnings in WASM build; remove some manual memory management

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -74,7 +74,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
   Log::PrintLogF(1, "\\subsection{Initial Reduction}\n\n");
   Log::OutputText("Reducing all polynomial hypotheses with respect to the "
                   "remaining set of hypotheses.\n\n");
-  if (Groebner::ReduceAll(vxps) == false) {
+  if (!Groebner::ReduceAll(vxps)) {
     return false;
   }
   Log::OutputText("Polynomial system after reduction:\n\n");
@@ -102,7 +102,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
                   "polynomials from the set,");
   Log::OutputText("and all non-empty results are added into Groebner set.\n\n");
   Log::PrintLogF(1, "\\begin{description}\n\n");
-  while (stopProcessing == false && k < vxps.size()) {
+  while (!stopProcessing && k < vxps.size()) {
     Log::PrintLogF(1, "\\item[Step %d]\n\n", k);
 
     Log::PrintLogF(1, "Adding new hypothesis to the Groebner set.");
@@ -121,7 +121,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
 #if 0
         // does it have gcd = 1 with any polynomial?
         bool gcdCond = false;
-		for (i = 0; i < k && gcdCond == false; i++)
+		for (i = 0; i < k && !gcdCond; i++)
         {
 			XTerm* m1 = (XTerm*)vxps[i]->GetTerm(0);
 			XTerm* m2 = (XTerm*)vxps[k]->GetTerm(0);
@@ -142,7 +142,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
         }
 #endif
 
-    for (i = 1; stopProcessing == false && i < k; i++) {
+    for (i = 1; !stopProcessing && i < k; i++) {
       Log::PrintLogF(
           1, "Reducing polynomial $p_{%d}$ with polynomial $p_{%d}$\n\n", k, i);
       //
@@ -179,20 +179,20 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
       xp->SPol(vxps[k]);
       _maxt = std::max(_maxt, xp->GetTotalTermCount());
 
-      if (Groebner::FullReduce(vxps, xp, -1) == false) {
+      if (!Groebner::FullReduce(vxps, xp, -1)) {
         xp->Dispose();
         stopProcessing = true;
       }
       Log::PrintLogF(4, "   After FullReduce:\n\n");
       // PolyReader::PrintPolynomials(vxps, 1);
 
-      if (stopProcessing == false) {
+      if (!stopProcessing) {
         if (!(xp->IsZero())) {
           Log::PrintLogF(1,
                          "Reduction is not zero, adding new S-polynomial:\n\n");
           PolyReader::PrintPolynomial(xp, 1);
           vxps.push_back(xp);
-          if (Groebner::ReduceAll(vxps) == false) {
+          if (!Groebner::ReduceAll(vxps)) {
             stopProcessing = true;
           }
         } else {
@@ -205,7 +205,7 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
 
     k++;
 
-    if (ITimeout::CheckTimeoutSafe() == false) {
+    if (!ITimeout::CheckTimeoutSafe()) {
       _bTimeout = true;
       stopProcessing = true;
     }
@@ -291,7 +291,7 @@ bool Groebner::ReduceAll(vxp &vxps) {
       k++;
     }
 
-    if (ITimeout::CheckTimeoutSafe() == false) {
+    if (!ITimeout::CheckTimeoutSafe()) {
       _bTimeout = true;
       return false;
     }
@@ -340,7 +340,7 @@ bool Groebner::FullReduce(vxp &vxps, XPolynomial *xp, int exclude) {
         Log::OutputText("Reducing with polynomial $p_{%d}$, the result is:\n\n",
                         candidate);
       }
-      if (Groebner::Reduce(xp, vxps[candidate]) == false) {
+      if (!Groebner::Reduce(xp, vxps[candidate])) {
         return false;
       }
       if (exclude == -1) {
@@ -348,7 +348,7 @@ bool Groebner::FullReduce(vxp &vxps, XPolynomial *xp, int exclude) {
       }
     }
 
-    if (ITimeout::CheckTimeoutSafe() == false) {
+    if (!ITimeout::CheckTimeoutSafe()) {
       _bTimeout = true;
       return false;
     }
@@ -375,8 +375,7 @@ int Groebner::CanReduce(XPolynomial *xp1, XPolynomial *xp2) {
   lmp = (XTerm *)xp2->GetTerm(0);
 
   // find monom in xp1 which is divisible with lm(p)
-  for (i = 0;
-       i < xp1->GetTermCount() && xp1->GetTerm(i)->Divisible(lmp) == false; i++)
+  for (i = 0; i < xp1->GetTermCount() && !xp1->GetTerm(i)->Divisible(lmp); i++)
     ;
 
   if (i >= xp1->GetTermCount()) {
@@ -412,7 +411,7 @@ bool Groebner::Reduce(XPolynomial* xp1, XPolynomial* xp2)
   lmp = (XTerm*)xp2->GetTerm(0);
 
   // find monom in xp1 which is divisible with lm(xp1)
-  for (i = 0; (uint)i < s1 && xp1->GetTerm(i)->Divisible(lmp) == false; i++);
+  for (i = 0; (uint)i < s1 && !xp1->GetTerm(i)->Divisible(lmp); i++);
 
   if (i == xp1->GetTermCount())
   {
@@ -446,7 +445,7 @@ bool Groebner::Reduce(XPolynomial* xp1, XPolynomial* xp2)
 
   _maxt = std::max(_maxt, xp1->GetTotalTermCount());
 
-  if (ITimeout::CheckTimeoutSafe() == false)
+  if (!ITimeout::CheckTimeoutSafe())
   {
 	  _bTimeout = true;
 	  return false;
@@ -476,7 +475,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   uint s1 = xp1->GetTermCount();
   for (ii = 0; (uint)ii < s1 && c1f1 == NULL; ii++) {
     c1f1 = (XTerm *)xp1->GetTerm(ii);
-    if (c1f1->Divisible(c2f2) == false) {
+    if (!c1f1->Divisible(c2f2)) {
       c1f1 = NULL;
     }
   }
@@ -521,7 +520,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
 
   _maxt = std::max(_maxt, xp1->GetTotalTermCount());
 
-  if (ITimeout::CheckTimeoutSafe() == false) {
+  if (!ITimeout::CheckTimeoutSafe()) {
     _bTimeout = true;
     return false;
   }
@@ -577,7 +576,7 @@ bool Groebner::GroebnerBasis2(vxp &vxps) {
         Log::OutputText("Forming S-pol of $p_{%d}$ and $p_{%d}$:", ii, jj);
         PolyReader::PrintPolynomial(xp, 1);
 
-        if (ITimeout::CheckTimeoutSafe() == false) {
+        if (!ITimeout::CheckTimeoutSafe()) {
           xp->Dispose();
           _bTimeout = true;
           Log::OutputEnumEnd("enumerate");
@@ -587,13 +586,13 @@ bool Groebner::GroebnerBasis2(vxp &vxps) {
         // do reduction
         FullReduce(vxps, xp, -2);
 
-        if (ITimeout::CheckTimeoutSafe() == false) {
+        if (!ITimeout::CheckTimeoutSafe()) {
           xp->Dispose();
           Log::OutputEnumEnd("enumerate");
           return false;
         }
 
-        if (xp && xp->IsZero() == false) {
+        if (xp && !xp->IsZero()) {
           // should be add
           pairs.push_back(xp);
           xp->AddRef();

--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -348,7 +348,7 @@ void PolyReader::PrintPolynomials(std::vector<XPolynomial *> &vpols, int level,
 
 void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
                                  bool tabular) {
-  if (Log::LogEnabledForLevel(level) == false) {
+  if (!Log::LogEnabledForLevel(level)) {
     return;
   }
 
@@ -432,7 +432,7 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
       }
 
       bool found = false;
-      while (found == false) {
+      while (!found) {
         if (pos == posb) {
           found = true;
         } else {
@@ -450,7 +450,7 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
             found = (diff == 0);
           }
         }
-        if (found == false) {
+        if (!found) {
           pos--;
         }
       }

--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -1,5 +1,6 @@
 #include "PolyReader.h"
 #include <algorithm>
+#include <string>
 
 XPolynomial *PolyReader::ReadXPolynomial(char *stream) {
   int start = 0, end = 0;
@@ -365,17 +366,14 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
     return;
   }
 
-  char *ltx = xp->PrintLatex();
+  std::string ltx = xp->PrintLatex();
   static int cnt = 0;
 
   // separate chunks
   const int chunk = 122;
   const int chunkDelta = 20;
   int curChunk = chunk;
-  int size = 0;
-  while (ltx[size++])
-    ;
-  size--; // added on 10.2015
+  const int size = ltx.size();
 
   // failed to print too large polynomials
   if (size > 1000) {
@@ -394,7 +392,6 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
       Log::PrintLogF(1, "\\ldots \\\\ \n ");
       Log::PrintLogF(2, "\n\n");
     }
-    delete[] ltx;
     return;
   }
 
@@ -493,9 +490,9 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
     char ct = ltx[pos];
     ltx[pos] = 0;
 
-    Log::PrintLogF(level, "%s", &ltx[posb]);
+    Log::PrintLogF(level, "%s", &ltx.data()[posb]);
     if (level == 1) {
-      Log::PrintLogF(2, "%s", &ltx[posb]);
+      Log::PrintLogF(2, "%s", &ltx.data()[posb]);
     }
     if (tabular) {
       Log::PrintLogF(level, "\\\\");
@@ -510,6 +507,4 @@ void PolyReader::PrintPolynomial(XPolynomial *xp, int level, int index,
   if (level == 1) {
     Log::PrintLogF(2, "</polynomial>\n");
   }
-
-  delete[] ltx;
 }

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -119,7 +119,7 @@ bool Reduce::ReduceLineCircleIntersection(
         Log::PrintLogF(level, "Reducing with pol %d\n\n", ii);
         PolyReader::PrintPolynomial(x, level);
 
-        if (xp12->IsZero() == false && x->LeadTerm(vecPointsIndex[1], vecPointsFree[1]))
+        if (!xp12->IsZero() && x->LeadTerm(vecPointsIndex[1], vecPointsFree[1]))
         {
             Log::PrintLogF(level, "Reducing last pol with x12 (second point) index %d:\n\n", vecPointsIndex[1]);
             polySystem[size - 1]->PseudoRemainder(x, vecPointsIndex[1], vecPointsFree[1]);
@@ -129,7 +129,7 @@ bool Reduce::ReduceLineCircleIntersection(
             polySystem[size - 2]->PseudoRemainder(x, vecPointsIndex[1], vecPointsFree[1]);
             PolyReader::PrintPolynomial(polySystem[size - 2], level);
         }
-        if (xp22->IsZero() == false && x->LeadTerm(vecPointsIndex[3], vecPointsFree[3]))
+        if (!xp22->IsZero() && x->LeadTerm(vecPointsIndex[3], vecPointsFree[3]))
         {
             Log::PrintLogF(level, "Reducing last pol with x2 (fourth point) index %d:\n\n", vecPointsIndex[3]);
             polySystem[size - 1]->PseudoRemainder(x, vecPointsIndex[3], vecPointsFree[3]);
@@ -570,12 +570,12 @@ bool Reduce::_IsTriangular(vxp& vxps, std::vector<int>& vars, int /* level */)
 			{
 				// is this variable exists in previous polynomials
 				bool varExists = false;
-				for (kk = 0, size1 = (int)vars.size(); kk < size1 && varExists == false; kk++)
+				for (kk = 0, size1 = (int)vars.size(); kk < size1 && !varExists; kk++)
 				{
 					varExists = vars[kk] == jj;
 				}
 
-				if (varExists == false)
+				if (!varExists)
 				{
 					if (hasNewVar)
 					{
@@ -594,7 +594,7 @@ bool Reduce::_IsTriangular(vxp& vxps, std::vector<int>& vars, int /* level */)
 			}
 		}
 
-		if (hasNewVar == false)
+		if (!hasNewVar)
 		{
 			// no new variable in this polynomial
 			// again, system not triangular

--- a/source/AlgebraicMethods/Term.cpp
+++ b/source/AlgebraicMethods/Term.cpp
@@ -178,7 +178,7 @@ Power *Term::GetPower(uint index) const { return _powers[index]; }
 // degree of variable with given index
 //
 int Term::VariableDeg(int index, bool free) const {
-  if (free == true && this->Type() == XTERM) {
+  if (free && this->Type() == XTERM) {
     XTerm *xt = (XTerm *)this;
     Term *t = xt->GetUFraction()->GetNumerator()->LeadTerm(index, free);
     if (t) {

--- a/source/AlgebraicMethods/UPolynomial.h
+++ b/source/AlgebraicMethods/UPolynomial.h
@@ -13,10 +13,10 @@ public:
 	UPolynomial(REAL cf);
 	UPolynomial* Clone() override;
 
-	TERM_TYPE Type() const;
+	TERM_TYPE Type() const override;
 
 	bool IsUnit() const;
 
 	// printint
-	void PrintLatex(std::ostream &os) const;
+	void PrintLatex(std::ostream &os) const override;
 };

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -15,11 +15,11 @@ public:
 
 	~UTerm();
 
-	void Dispose();
+	void Dispose() override;
 
 	UTerm* Clone() override;
 
-	TERM_TYPE Type() const;
+	TERM_TYPE Type() const override;
 
 	REAL GetCoeff() const;
 	void SetCoeff(REAL coeff);
@@ -29,17 +29,17 @@ public:
 	bool IsUnit() const;
 
 	// aritmetic operations
-	int Mul(Term* ut);
-	int Mul(REAL r);
-	int Divide(Term* ut);
-	int Inverse();
-	bool IsZero() const;
+	int Mul(Term* ut) override;
+	int Mul(REAL r) override;
+	int Divide(Term* ut) override;
+	int Inverse() override;
+	bool IsZero() const override;
 
 	// printing
-	void PrettyPrint() const;
-	void PrintLatex(std::ostream &os) const;
+	void PrettyPrint() const override;
+	void PrintLatex(std::ostream &os) const override;
 
 	// overriden methods
-	int Compare(Term* other) const;
-	void Merge(Term* t);
+	int Compare(Term* other) const override;
+	void Merge(Term* t) override;
 };

--- a/source/AlgebraicMethods/Wu.cpp
+++ b/source/AlgebraicMethods/Wu.cpp
@@ -20,7 +20,7 @@ PROVER_STATUS Wu::Prove(vxp &vxps, XPolynomial *xpConclusion,
     std::vector<int> vars;
     // if (retValue && Wu::_Triangulate(vxps, vars) == false)
     if (retValue == PROVER_STATUS_INPROGRESS &&
-        Reduce::Triangulate(vxps, vars, 1, &_maxt) == false) {
+        !Reduce::Triangulate(vxps, vars, 1, &_maxt)) {
       retValue = PROVER_STATUS_OTHER;
     }
     if (retValue == PROVER_STATUS_INPROGRESS &&
@@ -323,12 +323,12 @@ bool Wu::_IsTriangular(vxp& vxps, vector<int>& vars)
 			{
 				// is this variable exists in previous polynomials
 				bool varExists = false;
-				for (kk = 0, size1 = (int)vars.size(); kk < size1 && varExists == false; kk++)
+				for (kk = 0, size1 = (int)vars.size(); kk < size1 && !varExists; kk++)
 				{
 					varExists = vars[kk] == jj;
 				}
 
-				if (varExists == false)
+				if (!varExists)
 				{
 					if (hasNewVar)
 					{
@@ -347,7 +347,7 @@ bool Wu::_IsTriangular(vxp& vxps, vector<int>& vars)
 			}
 		}
 
-		if (hasNewVar == false)
+		if (!hasNewVar)
 		{
 			// no new variable in this polynomial
 			// again, system not triangular
@@ -380,7 +380,7 @@ bool Wu::_FinalRemainder(vxp &vxps, std::vector<int> &vars,
   Log::OutputText("with respect to the triangular system.\n\n");
   int size = (int)vxps.size();
   Log::OutputEnumBegin("enumerate");
-  for (int ii = size - 1; ii >= 0 && xpConclusion->IsZero() == false; ii--) {
+  for (int ii = size - 1; ii >= 0 && !xpConclusion->IsZero(); ii--) {
     Log::OutputEnumItemBegin();
     Log::OutputText("Pseudo remainder with $p_{%d}$ over variable $x_{%d}$:\n",
                     ii, vars[ii]);
@@ -411,17 +411,16 @@ bool Wu::_FinalRemainder(vxp &vxps, std::vector<int> &vars,
 bool Wu::_IsLinearSystem(vxp &vxps) {
   bool retValue = true;
 
-  for (int ii = 0, size = vxps.size(); ii < size && retValue == true; ii++) {
+  for (int ii = 0, size = vxps.size(); ii < size && retValue; ii++) {
     XPolynomial *xp = vxps[ii];
 
     // check all terms
-    for (int jj = 0, size1 = xp->GetTermCount(); jj < size1 && retValue == true;
-         jj++) {
+    for (int jj = 0, size1 = xp->GetTermCount(); jj < size1 && retValue; jj++) {
       XTerm *xt = (XTerm *)xp->GetTerm(jj);
 
       // check all powers
       for (int kk = 0, size2 = xt->GetPowerCount();
-           kk < size2 && retValue == true; kk++) {
+           kk < size2 && retValue; kk++) {
         retValue = (xt->GetPower(kk)->GetDegree() == 1);
       }
     }

--- a/source/AlgebraicMethods/XPolynomial.h
+++ b/source/AlgebraicMethods/XPolynomial.h
@@ -18,7 +18,7 @@ public:
 	XPolynomial(bool free, int index);
 	XPolynomial* Clone() override;
 
-	TERM_TYPE Type() const;
+	TERM_TYPE Type() const override;
 
 	static int maxt();
 
@@ -37,7 +37,7 @@ public:
 	void PseudoRemainder(XPolynomial* xp, int index, bool free = false, XPolynomial* xpDivisionResult = NULL);
 
 	// printing
-	void PrintLatex(std::ostream &os) const;
+	void PrintLatex(std::ostream &os) const override;
 	char* PrintLatex() const;
 };
 

--- a/source/AlgebraicMethods/XPolynomial.h
+++ b/source/AlgebraicMethods/XPolynomial.h
@@ -3,6 +3,7 @@
 #include "Polynomial.h"
 #include "XTerm.h"
 #include <iostream>
+#include <string>
 
 class XPolynomial : public Polynomial
 {
@@ -38,7 +39,7 @@ public:
 
 	// printing
 	void PrintLatex(std::ostream &os) const override;
-	char* PrintLatex() const;
+	std::string PrintLatex() const;
 };
 
 typedef std::vector<XPolynomial*> vxp;

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -17,7 +17,7 @@ public:
 	XTerm* Clone() override;
 	XTerm* ClonePowers();
 
-	TERM_TYPE Type() const;
+	TERM_TYPE Type() const override;
 
 	static XTerm* CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint index2);
 
@@ -26,18 +26,18 @@ public:
 	void AddPower(Power* xp);
 
 	// aritmetic operations
-	int Mul(Term* ut);
-	int Mul(REAL r);
-	int Divide(Term* ut);
+	int Mul(Term* ut) override;
+	int Mul(REAL r) override;
+	int Divide(Term* ut) override;
     void DivideMonoms(XTerm* t);
-	int Inverse();
-	bool IsZero() const;
+	int Inverse() override;
+	bool IsZero() const override;
 
 	// printing
-	void PrettyPrint() const;
-	void PrintLatex(std::ostream &os) const;
+	void PrettyPrint() const override;
+	void PrintLatex(std::ostream &os) const override;
 
 	// overriden methods
-	int Compare(Term* t) const;
-	void Merge(Term* t);
+	int Compare(Term* t) const override;
+	void Merge(Term* t) override;
 };

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -1,6 +1,5 @@
 #include "PolyReader.h"
 #include "XPolynomial.h"
-#include <cstring>
 #include <iostream>
 #include <memory>
 #include <new>
@@ -412,7 +411,7 @@ void XPolynomial::SimpleReduction() {
 //
 // latex output
 //
-char *XPolynomial::PrintLatex() const {
+std::string XPolynomial::PrintLatex() const {
   std::ostringstream ss;
 
   uint size = this->GetTermCount();
@@ -427,26 +426,24 @@ char *XPolynomial::PrintLatex() const {
     ss << '0';
   }
 
-  const std::string str = ss.str();
-  char *res = new char[str.size() + 1];
-  memcpy(res, str.c_str(), str.size() + 1);
+  std::string str = ss.str();
 
   // +- => -
   // -+ => -
   // N1x => Nx
   // N1u => Nu
   // where N is non-number char
-  _ResReplace(res, '+', '-', '-', false);
-  _ResReplace(res, '-', '+', '-', false);
+  _ResReplace(str.data(), '+', '-', '-', false);
+  _ResReplace(str.data(), '-', '+', '-', false);
 
 #if 1
   // not safe for short latex output!
   // u_1x_2
-  _ResReplace(res, '1', 'x', 'x', true);
-  _ResReplace(res, '1', 'u', 'u', true);
+  _ResReplace(str.data(), '1', 'x', 'x', true);
+  _ResReplace(str.data(), '1', 'u', 'u', true);
 #endif
 
-  return res;
+  return str;
 }
 
 void XPolynomial::PrintLatex(std::ostream & /* sb */) const {}

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -463,7 +463,7 @@ void XPolynomial::_ResReplace(char *res, char l1, char l2, char r1,
 
     // search pattern
     int ii = 0;
-    while (replaced == false && res[ii]) {
+    while (!replaced && res[ii]) {
       if (res[ii] == l1 && res[ii + 1] == l2) {
         // check non-number condition
         if (!(nnCond && ii > 0 &&

--- a/source/GraphDrawing/graph_util.cpp
+++ b/source/GraphDrawing/graph_util.cpp
@@ -191,7 +191,7 @@ std::map<int, int> GraphUtil::getDummyMap(std::map<int, std::vector<int> > neigh
 }
 
 std::string GraphUtil::printbool(bool argument) {
-  return ((argument == true) ? "TRUE" : "FALSE");
+  return argument ? "TRUE" : "FALSE";
 }
 
 bool **GraphUtil::allocateMatrix(bool **adjacencyMatrix, int size) {

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -530,7 +530,7 @@ bool CAlgMethod::_FindPoints() {
 
 bool CAlgMethod::_AddDependantPoint(const std::string &name, int *pLastDepIndex,
                                     bool addCommand) {
-  if (_ExistsPoint(name) == false) {
+  if (!_ExistsPoint(name)) {
     Point *p = new Point(false, false, name);
     _points.push_back(p);
 
@@ -553,7 +553,7 @@ bool CAlgMethod::_AddDependantPoint(const std::string &name, int *pLastDepIndex,
 bool CAlgMethod::_AddFreePoint(const std::string &name, bool addCommand,
                                const std::string & /* xc */,
                                const std::string & /* yc */) {
-  if (_ExistsPoint(name) == false) {
+  if (!_ExistsPoint(name)) {
     Point *p = new Point(true, true, name);
     _points.push_back(p);
 
@@ -607,12 +607,12 @@ bool CAlgMethod::_AddFreePoint(const std::string &name, bool addCommand,
 #endif
 
     // set undetermined positions
-    if (p->X.Determined == false) {
+    if (!p->X.Determined) {
       p->X.Determined = true;
       p->X.Index = ++lastFreeIndex;
       ++freePointCoordinatesCount;
     }
-    if (p->Y.Determined == false) {
+    if (!p->Y.Determined) {
       p->Y.Determined = true;
       p->Y.Index = ++lastFreeIndex;
       ++freePointCoordinatesCount;
@@ -715,12 +715,12 @@ Line *CAlgMethod::_FindLine(Point *p1, Point *p2) {
     bool containp2 = false;
     l = _lines[ii];
     for (int jj = 0, size1 = l->Points.size();
-         jj < size1 && (containp1 == false || containp2 == false); jj++) {
+         jj < size1 && (!containp1 || !containp2); jj++) {
       containp1 = containp1 || l->Points[jj] == p1;
       containp2 = containp2 || l->Points[jj] == p2;
     }
 
-    if (containp1 == false || containp2 == false) {
+    if (!containp1 || !containp2) {
       l = NULL;
     }
   }
@@ -1063,7 +1063,7 @@ bool CAlgMethod::_FindLinesCircles() {
       for (jj = 0, size1 = l->Points.size(); jj < size1; jj++) {
         HalfPoint *hp = l->Angle == 0 ? &l->Points[jj]->Y : &l->Points[jj]->X;
 
-        if (hp->Free && minFree == false) {
+        if (hp->Free && !minFree) {
           minFree = true;
           minIndex = -1;
         }
@@ -1084,7 +1084,7 @@ bool CAlgMethod::_FindLinesCircles() {
           // minFree
           //==
           // true)
-          if (hp->Free != hp1->Free && minFree == true && hp1->Free == false) {
+          if (hp->Free != hp1->Free && minFree && !hp1->Free) {
             hp1->Free = true;
             hp1->Index = ++lastFreeIndex;
           }
@@ -1511,13 +1511,13 @@ void CAlgMethod::_AddCondition(XPolynomial *xp, bool check, vxp *polySystem) {
     add = false;
   } else if (check) {
     // is there same condition
-    for (ii = 0, size = vxps.size(); add == true && ii < size; ii++) {
+    for (ii = 0, size = vxps.size(); add && ii < size; ii++) {
       xp1 = polySystem ? polySystem->at(ii)->Clone() : vxps[ii]->Clone();
       xp1->Subtract(xp);
 
-      add = add && xp1->IsZero() == false;
+      add = add && !xp1->IsZero();
 
-      if (add == false) {
+      if (!add) {
         Log::PrintLogF(1, "Rejected, there is already same condition!\n\n");
       }
 
@@ -1528,9 +1528,9 @@ void CAlgMethod::_AddCondition(XPolynomial *xp, bool check, vxp *polySystem) {
         xp1 = polySystem ? polySystem->at(ii)->Clone() : vxps[ii]->Clone();
         xp1->Add(xp);
 
-        add = add && xp1->IsZero() == false;
+        add = add && !xp1->IsZero();
 
-        if (add == false) {
+        if (!add) {
           Log::PrintLogF(1, "Rejected, there is already same condition!\n\n");
         }
 
@@ -2122,7 +2122,7 @@ void CAlgMethod::_ExtractConjecturePolynomial() {
     XPolynomial *xpConjecture =
         _ExtractPolynomialExpression(&vpConjectures[ii]);
     if (xpConjecture &&
-        xpConjecture->IsZero() == false) // zero polynomial is always true!
+        !xpConjecture->IsZero()) // zero polynomial is always true!
     {
       vxpConjectures.push_back(xpConjecture);
     } else if (xpConjecture) {
@@ -2350,7 +2350,7 @@ enum eGCLC_conjecture_status
 CAlgMethod::_Prove(const CGCLCProverExpression & /* pConj */) {
   eGCLC_conjecture_status eRet = e_unknown;
 
-  if (this->ValidConjecture() == false) {
+  if (!this->ValidConjecture()) {
     Log::PrintLogF(
         1, "Please provide valid conjecture before calling Prove method!\n\n");
     return eRet;
@@ -2508,8 +2508,7 @@ bool CAlgMethod::_CollinearPoints(Point *a, Point *b, Point *c) {
 
   if (l) {
     // does this line contains point c
-    for (int ii = 0, size = l->Points.size(); ii < size && retValue == false;
-         ii++) {
+    for (int ii = 0, size = l->Points.size(); ii < size && !retValue; ii++) {
       retValue = l->Points[ii] == c;
     }
   }
@@ -2577,8 +2576,7 @@ bool CAlgMethod::_RationalizeConjecture(CGCLCProverExpression *conjecture) {
           throw - 1;
         }
 
-        if (_CollinearPoints(A, B, C) == false ||
-            _CollinearPoints(A, B, D) == false) {
+        if (!_CollinearPoints(A, B, C) || !_CollinearPoints(A, B, D)) {
           // create ep_parallel conjecture
           vpConjectures.push_back(
               CGCLCProverExpression(ep_parallel, eA->GetName(), eB->GetName(),

--- a/source/TheoremProver/AlgMethod.h
+++ b/source/TheoremProver/AlgMethod.h
@@ -101,11 +101,10 @@ struct Line {
 
     // add point to the list
     bool containPoint = false;
-    for (int ii = 0, size = Points.size(); ii < size && containPoint == false;
-         ii++) {
+    for (int ii = 0, size = Points.size(); ii < size && !containPoint; ii++) {
       containPoint = Points[ii] == p;
     }
-    if (containPoint == false) {
+    if (!containPoint) {
       Points.push_back(p);
     }
   }

--- a/source/Utils/Utils.cpp
+++ b/source/Utils/Utils.cpp
@@ -111,7 +111,7 @@ bool convert(const std::string &word, double &number) {
         if ((sign == 1 && i == 1) || (sign == -1 && i == 2))
           return false;
 
-        if (exponent == false) {
+        if (!exponent) {
           decimal = true;
           if (!convert(word.substr(i), exp))
             return false;
@@ -122,14 +122,14 @@ bool convert(const std::string &word, double &number) {
           return false;
       } else {
         if (c != '.') {
-          if (decimal == false)
+          if (!decimal)
             number = 10 * number + (double)(c - '0');
           else {
             dp = dp * 10.00;
             number = number + ((double)(c - '0')) / dp;
           }
         } else {
-          if (decimal == false)
+          if (!decimal)
             decimal = true;
           else
             return false;


### PR DESCRIPTION
* mark overridden virtual functions as `override`, which squashes some compiler warnings
* remove manual memory management of `PrintLatex`