### PR TITLE
reference count 'Power' with 'std::shared_ptr'

### DIFF
--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -1,5 +1,6 @@
 #include "PolyReader.h"
 #include <algorithm>
+#include <memory>
 #include <string>
 
 XPolynomial *PolyReader::ReadXPolynomial(char *stream) {
@@ -91,9 +92,8 @@ XTerm *PolyReader::_ReadXTerm(char *stream, int s, int e) {
       _Assert(e1 >= 0, "Right bracket missing!");
 
       // create Power and add it to the xpol
-      Power *xp = _ReadXPower(stream, s1, e1);
+      std::shared_ptr<Power> xp = _ReadXPower(stream, s1, e1);
       xt->AddPower(xp);
-      xp->Dispose();
     }
   } while (s1 > 0);
 
@@ -208,9 +208,8 @@ UTerm *PolyReader::_ReadUTerm(char *stream, int s, int e) {
       _Assert(e1 >= 0, "Right bracket missing!");
 
       // create UTerm and add it to the xpol
-      Power *up = _ReadUPower(stream, s1, e1);
+      std::shared_ptr<Power> up = _ReadUPower(stream, s1, e1);
       ut->AddPower(up);
-      up->Dispose();
     }
   } while (s1 > 0);
 
@@ -221,7 +220,7 @@ UTerm *PolyReader::_ReadUTerm(char *stream, int s, int e) {
 // Power is a pair of index and degree
 // {1, 2}
 //
-Power *PolyReader::_ReadUPower(char *stream, int s, int /*e*/) {
+std::shared_ptr<Power> PolyReader::_ReadUPower(char *stream, int s, int /*e*/) {
 #if DESER_DBG
   // debug
   Log::PrintLogF(0, "uw: ");
@@ -237,16 +236,14 @@ Power *PolyReader::_ReadUPower(char *stream, int s, int /*e*/) {
   Log::PrintLogF(0, "  index = %d, degree = %d\n", index, degree);
 #endif
 
-  Power *up = new Power(index, degree, VAR_TYPE_U);
-
-  return up;
+  return std::make_shared<Power>(index, degree, VAR_TYPE_U);
 }
 
 //
 // Power is a pair of index and degree
 // {1, 2}
 //
-Power *PolyReader::_ReadXPower(char *stream, int s, int /*e*/) {
+std::shared_ptr<Power> PolyReader::_ReadXPower(char *stream, int s, int /*e*/) {
 #if DESER_DBG
   // debug
   Log::PrintLogF(0, "xw: ");
@@ -262,9 +259,7 @@ Power *PolyReader::_ReadXPower(char *stream, int s, int /*e*/) {
   Log::PrintLogF(0, "  index = %d, degree = %d\n", index, degree);
 #endif
 
-  Power *xp = new Power(index, degree, VAR_TYPE_X);
-
-  return xp;
+  return std::make_shared<Power>(index, degree, VAR_TYPE_X);
 }
 
 void PolyReader::_Print(char *stream, int s, int e) {

--- a/source/AlgebraicMethods/PolyReader.h
+++ b/source/AlgebraicMethods/PolyReader.h
@@ -2,6 +2,7 @@
 
 #include "stdinc.h"
 #include "XPolynomial.h"
+#include <memory>
 
 class PolyReader
 {
@@ -21,8 +22,8 @@ private:
 	static UPolynomialFraction* _ReadUFraction(char* stream, int s, int e);
 	static UPolynomial* _ReadUPolynomial(char* stream, int s, int e);
 	static UTerm* _ReadUTerm(char* stream, int s, int e);
-	static Power* _ReadUPower(char* stream, int s, int e);
-	static Power* _ReadXPower(char* stream, int s, int e);
+	static std::shared_ptr<Power> _ReadUPower(char* stream, int s, int e);
+	static std::shared_ptr<Power> _ReadXPower(char* stream, int s, int e);
 
 
 public:

--- a/source/AlgebraicMethods/Power.cpp
+++ b/source/AlgebraicMethods/Power.cpp
@@ -1,5 +1,7 @@
+#include "Log.h"
 #include "Power.h"
 #include <iostream>
+#include <memory>
 
 Power::Power(uint index, uint degree, VAR_TYPE varType)
 : _index(index), _degree(degree), _vType(varType)
@@ -22,19 +24,9 @@ Power::~Power()
 	DESTR("power");
 }
 
-Power* Power::Clone()
+std::shared_ptr<Power> Power::Clone()
 {
-	return new Power(_index, _degree, _vType);
-}
-
-void Power::Dispose()
-{
-	_refCount --;
-
-	if (_refCount == 0)
-	{
-		delete this;
-	}
+	return std::make_shared<Power>(_index, _degree, _vType);
 }
 
 uint Power::GetIndex() const

--- a/source/AlgebraicMethods/Power.h
+++ b/source/AlgebraicMethods/Power.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "Object.h"
+#include "stdinc.h"
 #include <iostream>
+#include <memory>
 
 /*************************************************************
 *
@@ -18,7 +19,7 @@ enum VAR_TYPE
 	VAR_TYPE_X = 2
 };
 
-class Power : public Object
+class Power
 {
 protected:
 	// index of variable
@@ -35,9 +36,8 @@ public:
 	void Construct(uint index, uint degree, VAR_TYPE varType);
 
 	~Power();
-	void Dispose();
 
-	Power* Clone();
+	std::shared_ptr<Power> Clone();
 
 	uint GetIndex() const;
 	void SetDegree(uint degree);

--- a/source/AlgebraicMethods/Term.cpp
+++ b/source/AlgebraicMethods/Term.cpp
@@ -27,10 +27,6 @@ Term::~Term() {
 	static int cnt = 0;
 	//Log::PrintLogF(0, "D:%d:%x\n", cnt++, this);
 #endif
-  for (int ii = 0, size = (int)_powers.size(); ii < size; ii++) {
-    _powers[ii]->Dispose();
-  }
-
   DESTR("term");
 }
 
@@ -74,8 +70,8 @@ void Term::MergePowers(Term *t, bool add) {
   int op = add ? 1 : -1;
 
   while (ii < cnt1 && jj < cnt2) {
-    Power *w1 = _powers[ii];
-    Power *w2 = t->_powers[jj];
+    Power *w1 = _powers[ii].get();
+    Power *w2 = t->_powers[jj].get();
 
     if (w1->GetIndex() == w2->GetIndex()) {
       // case 1, w1 == w2
@@ -87,7 +83,6 @@ void Term::MergePowers(Term *t, bool add) {
 
       if (degree == 0) {
         // remove power
-        w1->Dispose();
         _powers.erase(_powers.begin() + ii);
 
         cnt1--;
@@ -134,7 +129,7 @@ void Term::MergePowers(Term *t, bool add) {
     }
 
     // add remaining powers
-    Power *w2 = t->_powers[jj];
+    Power *w2 = t->_powers[jj].get();
     _powers.push_back(w2->Clone());
     jj++;
   }
@@ -172,7 +167,7 @@ bool Term::Divisible(Term *t) const {
 
 uint Term::GetPowerCount() const { return (uint)_powers.size(); }
 
-Power *Term::GetPower(uint index) const { return _powers[index]; }
+Power *Term::GetPower(uint index) const { return _powers[index].get(); }
 
 //
 // degree of variable with given index
@@ -247,7 +242,6 @@ void Term::ChangePowerDegree(int index, int change) {
 // Remove power at index
 //
 void Term::RemovePower(uint index) {
-  _powers[index]->Dispose();
   _powers.erase(_powers.begin() + index);
 }
 

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -28,7 +28,7 @@ class Term : public Object
 {
 protected:
 	// list of powers
-	std::vector<Power*> _powers;
+	std::vector<std::shared_ptr<Power>> _powers;
 
 public:
 	Term();

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <memory>
 
 UTerm::UTerm(REAL coeff)
 : _coeff(coeff)
@@ -39,9 +40,8 @@ UTerm* UTerm::Clone()
 	uint count = this->GetPowerCount();
     for (unsigned int ii = 0; ii < count; ii++)
 	{
-		Power* uwClone = this->GetPower(ii)->Clone();
+		std::shared_ptr<Power> uwClone = this->GetPower(ii)->Clone();
 		utClone->AddPower(uwClone);
-		uwClone->Dispose();
 	}
 
 	return utClone;
@@ -65,9 +65,8 @@ void UTerm::SetCoeff(REAL coeff)
 // add on the end
 // this method is used in deserialization
 //
-void UTerm::AddPower(Power* power)
+void UTerm::AddPower(std::shared_ptr<Power> power)
 {
-	power->AddRef();
 	_powers.push_back(power);
 }
 

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -3,6 +3,7 @@
 #include "Power.h"
 #include "Term.h"
 #include <iostream>
+#include <memory>
 
 class UTerm : public Term
 {
@@ -24,7 +25,7 @@ public:
 	REAL GetCoeff() const;
 	void SetCoeff(REAL coeff);
 
-	void AddPower(Power* power);
+	void AddPower(std::shared_ptr<Power> power);
 
 	bool IsUnit() const;
 

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -2,6 +2,7 @@
 #include "XPolynomial.h"
 #include "PolyReader.h"
 #include <iostream>
+#include <memory>
 
 XTerm::XTerm()
 : _frac(NULL)
@@ -31,9 +32,8 @@ XTerm* XTerm::Clone()
 	// powers
 	for (uint ii = 0; ii < this->GetPowerCount(); ii++)
 	{
-		Power* xwClone = this->GetPower(ii)->Clone();
+		std::shared_ptr<Power> xwClone = this->GetPower(ii)->Clone();
 		xtClone->AddPower(xwClone);
-		xwClone->Dispose();
 	}
 
 	return xtClone;
@@ -46,9 +46,8 @@ XTerm* XTerm::ClonePowers()
 	// powers
 	for (uint ii = 0; ii < this->GetPowerCount(); ii++)
 	{
-		Power* xwClone = this->GetPower(ii)->Clone();
+		std::shared_ptr<Power> xwClone = this->GetPower(ii)->Clone();
 		xtClone->AddPower(xwClone);
-		xwClone->Dispose();
 	}
 
 	return xtClone;
@@ -75,7 +74,6 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 	}
 
 	XTerm* xt = new XTerm();
-	Power *p1, *p2;
 
 	UPolynomialFraction* upf;
 	if (f1 || f2)
@@ -97,22 +95,8 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 	xt->SetUFraction(upf);
 	upf->Dispose();
 
-	if (f1)
-	{
-		p1 = new Power(index1, 1, VAR_TYPE_U);
-	}
-	else
-	{
-		p1 = new Power(index1, 1, VAR_TYPE_X);
-	}
-	if (f2)
-	{
-		p2 = new Power(index2, 1, VAR_TYPE_U);
-	}
-	else
-	{
-		p2 = new Power(index2, 1, VAR_TYPE_X);
-	}
+	auto p1 = std::make_shared<Power>(index1, 1, f1 ? VAR_TYPE_U : VAR_TYPE_X);
+	auto p2 = std::make_shared<Power>(index2, 1, f2 ? VAR_TYPE_U : VAR_TYPE_X);
 
 	if (!f1)
 	{
@@ -172,15 +156,6 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 	}
 #endif
 
-	if (p1)
-	{
-		p1->Dispose();
-	}
-	if (p2)
-	{
-		p2->Dispose();
-	}
-
 	return xt;
 }
 
@@ -207,9 +182,8 @@ void XTerm::SetUFraction(UPolynomialFraction* uf)
 // add xpower at the end
 // deserialization method
 //
-void XTerm::AddPower(Power* xp)
+void XTerm::AddPower(std::shared_ptr<Power> xp)
 {
-	xp->AddRef();
 	_powers.push_back(xp);
 }
 

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -4,6 +4,7 @@
 #include "Power.h"
 #include "UPolynomialFraction.h"
 #include <iostream>
+#include <memory>
 
 class XTerm : public Term
 {
@@ -23,7 +24,7 @@ public:
 
 	UPolynomialFraction* GetUFraction() const;
 	void SetUFraction(UPolynomialFraction* uf);
-	void AddPower(Power* xp);
+	void AddPower(std::shared_ptr<Power> xp);
 
 	// aritmetic operations
 	int Mul(Term* ut) override;

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -41,16 +41,14 @@ XPolynomial::XPolynomial(bool free, int index) {
     UPolynomialFraction *uf = new UPolynomialFraction(1);
 
     if (free) {
-      Power *up = new Power(index, 1, VAR_TYPE_U);
+      auto up = std::make_shared<Power>(index, 1, VAR_TYPE_U);
 
       UTerm *ut = (UTerm *)uf->GetNumerator()->GetTerm(0);
       ut->AddPower(up);
-      up->Dispose();
     } else {
-      Power *xpow = new Power(index, 1, VAR_TYPE_X);
+      auto xpow = std::make_shared<Power>(index, 1, VAR_TYPE_X);
 
       xt->AddPower(xpow);
-      xpow->Dispose();
     }
 
     xt->SetUFraction(uf);


### PR DESCRIPTION
This avoids the need for manual `Dispose` calls, removing an opportunity for accidental omissions. By leaning on the standard library, we also get a reference counting implementation optimised for the target platform.