### PR TITLE
remove 'auto'; minor simplification; avoid some memory leaks

### DIFF
--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -78,7 +78,8 @@ XTerm *PolyReader::_ReadXTerm(char *stream, int s, int e) {
     REAL cf;
     sscanf(&stream[e1 + 1], "%lf", &cf);
 
-    auto uf = std::make_shared<UPolynomialFraction>(cf);
+    std::shared_ptr<UPolynomialFraction> uf =
+      std::make_shared<UPolynomialFraction>(cf);
     xt->SetUFraction(uf);
   }
 
@@ -130,7 +131,8 @@ std::shared_ptr<UPolynomialFraction> PolyReader::_ReadUFraction(char *stream, in
   UPolynomial *up2 = _ReadUPolynomial(stream, s1, e1);
 
   // create UFraction
-  auto uf = std::make_shared<UPolynomialFraction>();
+  std::shared_ptr<UPolynomialFraction> uf =
+    std::make_shared<UPolynomialFraction>();
 
   uf->SetNumerator(up1);
   up1->Dispose();

--- a/source/AlgebraicMethods/UPolynomialFraction.cpp
+++ b/source/AlgebraicMethods/UPolynomialFraction.cpp
@@ -36,7 +36,8 @@ UPolynomialFraction::~UPolynomialFraction()
 
 std::shared_ptr<UPolynomialFraction> UPolynomialFraction::Clone()
 {
-	auto ufClone = std::make_shared<UPolynomialFraction>();
+	std::shared_ptr<UPolynomialFraction> ufClone =
+	  std::make_shared<UPolynomialFraction>();
 
 	UPolynomial* upNumClone = this->GetNumerator()->Clone();
 	UPolynomial* upDenClone = this->GetDenominator()->Clone();

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -87,8 +87,10 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 	}
 	xt->SetUFraction(upf);
 
-	auto p1 = std::make_shared<Power>(index1, 1, f1 ? VAR_TYPE_U : VAR_TYPE_X);
-	auto p2 = std::make_shared<Power>(index2, 1, f2 ? VAR_TYPE_U : VAR_TYPE_X);
+	std::shared_ptr<Power> p1 =
+	  std::make_shared<Power>(index1, 1, f1 ? VAR_TYPE_U : VAR_TYPE_X);
+	std::shared_ptr<Power> p2 =
+	  std::make_shared<Power>(index2, 1, f2 ? VAR_TYPE_U : VAR_TYPE_X);
 
 	if (!f1)
 	{

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -16,7 +16,8 @@ XPolynomial::~XPolynomial() { DESTR("xpoly"); }
 XPolynomial::XPolynomial(REAL x) {
   if (x != 0) {
     XTerm *xt = new XTerm();
-    auto uf = std::make_shared<UPolynomialFraction>(x);
+    std::shared_ptr<UPolynomialFraction> uf =
+      std::make_shared<UPolynomialFraction>(x);
     xt->SetUFraction(uf);
 
     this->AddTerm(xt);
@@ -34,15 +35,16 @@ XPolynomial::XPolynomial(bool free, int index) {
     // empty polynomial, ie zero polynomial
   } else {
     XTerm *xt = new XTerm();
-    auto uf = std::make_shared<UPolynomialFraction>(1);
+    std::shared_ptr<UPolynomialFraction> uf =
+      std::make_shared<UPolynomialFraction>(1);
 
     if (free) {
-      auto up = std::make_shared<Power>(index, 1, VAR_TYPE_U);
+      std::shared_ptr<Power> up = std::make_shared<Power>(index, 1, VAR_TYPE_U);
 
       UTerm *ut = (UTerm *)uf->GetNumerator()->GetTerm(0);
       ut->AddPower(up);
     } else {
-      auto xpow = std::make_shared<Power>(index, 1, VAR_TYPE_X);
+      std::shared_ptr<Power> xpow = std::make_shared<Power>(index, 1, VAR_TYPE_X);
 
       xt->AddPower(xpow);
     }
@@ -340,7 +342,8 @@ bool XPolynomial::_PseudoRemainder(XPolynomial *xp, int index, bool free,
     }
   } else {
     XTerm *unit = new XTerm();
-    auto unitFraction = std::make_shared<UPolynomialFraction>(1);
+    std::shared_ptr<UPolynomialFraction> unitFraction =
+      std::make_shared<UPolynomialFraction>(1);
     unit->SetUFraction(unitFraction);
     q->AddTerm(unit);
     unit->Dispose();

--- a/source/GCLCEngine/GCLC.cpp
+++ b/source/GCLCEngine/GCLC.cpp
@@ -1439,7 +1439,7 @@ enum GCLCError CGCLC::Execute() {
 // ///////////////////////////////////////////////////////////////
 
 enum GCLCcommands CGCLC::choose_command(const std::string &word) {
-  auto c = KeyWords.find(word);
+  std::map<std::string, enum GCLCcommands>::iterator c = KeyWords.find(word);
   if (c == KeyWords.end())
     return gclc_unknowncommand;
   else

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <memory>
+#include <utility>
 
 // ----------------------------------------------------------------------------
 
@@ -773,8 +774,9 @@ bool CAlgMethod::_FindLinesCircles() {
     case med:
       l = _FindLine(it->arg[0]);
       if (l == NULL) {
-        l = new Line(it->arg[0]);
-        _lines.emplace_back(l);
+        std::unique_ptr<Line> line{new Line(it->arg[0])};
+        l = line.get();
+        _lines.push_back(std::move(line));
       }
       break;
     case midpoint:
@@ -820,8 +822,9 @@ bool CAlgMethod::_FindLinesCircles() {
       // probably new line is defined
       l = _FindLine(it->arg[0]);
       if (l == NULL) {
-        l = new Line(it->arg[0]);
-        _lines.emplace_back(l);
+        std::unique_ptr<Line> line{new Line(it->arg[0])};
+        l = line.get();
+        _lines.push_back(std::move(line));
       }
 
       if (it->type != p_bis) {
@@ -843,15 +846,17 @@ bool CAlgMethod::_FindLinesCircles() {
 
         l = _FindLine(it->arg[1]);
         if (l == NULL) {
-          l = new Line(it->arg[1]);
-          _lines.emplace_back(l);
+          std::unique_ptr<Line> line{new Line(it->arg[1])};
+          l = line.get();
+          _lines.push_back(std::move(line));
         }
         l->AddPoint(p);
 
         l = _FindLine(it->arg[2]);
         if (l == NULL) {
-          l = new Line(it->arg[2]);
-          _lines.emplace_back(l);
+          std::unique_ptr<Line> line{new Line(it->arg[2])};
+          l = line.get();
+          _lines.push_back(std::move(line));
         }
         l->AddPoint(p);
       } else {
@@ -886,15 +891,17 @@ bool CAlgMethod::_FindLinesCircles() {
 
       l = _FindLine(it->arg[0]);
       if (l == NULL) {
-        l = new Line(it->arg[0]);
-        _lines.emplace_back(l);
+        std::unique_ptr<Line> line{new Line(it->arg[0])};
+        l = line.get();
+        _lines.push_back(std::move(line));
       }
       l->AddPoint(p);
 
       l = _FindLine(it->arg[2]);
       if (l == NULL) {
-        l = new Line(it->arg[2]);
-        _lines.emplace_back(l);
+        std::unique_ptr<Line> line{new Line(it->arg[2])};
+        l = line.get();
+        _lines.push_back(std::move(line));
       }
       break;
     case p_circle:
@@ -1155,8 +1162,9 @@ bool CAlgMethod::_HalfPointsEquals(Point *p1, Point *p2, bool xAxis) {
 //
 Line *CAlgMethod::_CreateLine(Point *p1, Point *p2) {
   std::string lName = p1->Name + p2->Name;
-  Line *l = new Line(lName);
-  _lines.emplace_back(l);
+  std::unique_ptr<Line> line{new Line(lName)};
+  Line *l = line.get();
+  _lines.push_back(std::move(line));
   l->AddPoint(p1);
   l->AddPoint(p2);
   l->implicit = true;

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -342,12 +342,11 @@ bool CAlgMethod::AddProverCommand(eGCLC_prover_command type, const std::string &
 // Is point with given name already created
 //
 bool CAlgMethod::_ExistsPoint(const std::string &name) {
-  bool retValue = false;
-  for (int ii = 0, size = _points.size(); ii < size && retValue == false;
-       ii++) {
-    retValue = (_points[ii]->Name == name);
+  for (const Point *p : _points) {
+    if (p->Name == name)
+      return true;
   }
-  return retValue;
+  return false;
 }
 
 // ----------------------------------------------------------------------------

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -641,16 +641,15 @@ Constant *CAlgMethod::_FindConstant(const std::string &name) {
 // Returns NULL if point does not exists.
 //
 Point *CAlgMethod::_FindPoint(const std::string &name) {
-  Point *p = NULL;
   if (name.empty()) {
-    return p;
+    return NULL;
   }
 
-  for (int ii = 0, size = _points.size(); ii < size && p == NULL; ii++) {
-    if (_points[ii]->Name == name)
-      p = _points[ii];
+  for (Point *p : _points) {
+    if (p->Name == name)
+      return p;
   }
-  return p;
+  return NULL;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
A few improvements:

* remove use of `auto`: As discussed on email, there is a shared desire to be more explicit about types
* abbreviate `_ExistsPoint`
* abbreviate `_FindPoint`
* manage constructed lines with `std::unique_ptr`