### PR TITLE
reference count 'Term' hierarchy with 'std::shared_ptr'

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -165,16 +165,14 @@ bool Groebner::GroebnerBasis(vxp &vxps) {
         continue;
       }
 
-      m1 = m1->Clone();
-      m1->GCDWith(m2);
-      if (m1->GetPowerCount() == 0) {
+      std::shared_ptr<Term> m1s = m1->Clone();
+      m1s->GCDWith(m2);
+      if (m1s->GetPowerCount() == 0) {
         Log::PrintLogF(1, "Polynomial will be reduced to zero because "
                           "$GCD(p_{%d}, p_{%d}) = 1$.\n\n",
                        i, k);
-        m1->Dispose();
         continue;
       }
-      m1->Dispose();
 
       xp = vxps[i]->Clone();
       xp->SPol(vxps[k]);
@@ -462,7 +460,7 @@ bool Groebner::Reduce(XPolynomial* xp1, XPolynomial* xp2)
 //   c2p1 - c1gp2 = c2c1f1g + c2q - c2c1gf2 - c1gr =
 //                = c2q - c1gr
 bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
-  XTerm *c1f1 = NULL, *c2f2 = NULL, *g = NULL;
+  XTerm *c1f1 = NULL, *c2f2 = NULL;
   // UPolynomialFraction *c1 = NULL, *c2 = NULL;
   int ii;
 
@@ -486,24 +484,22 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   }
 
   // divide f1/f2
-  g = c1f1->Clone();
+  std::shared_ptr<Term> g = c1f1->Clone();
   g->Divide(c2f2);
 
   // multiply first with c2 (must create c2 first)
   XPolynomial *pc2 = new XPolynomial();
-  XTerm *tc2 = new XTerm();
+  std::shared_ptr<XTerm> tc2 = std::make_shared<XTerm>();
   std::shared_ptr<UPolynomialFraction> c2Clone = c2f2->GetUFraction()->Clone();
   tc2->SetUFraction(c2Clone);
   pc2->AddTerm(tc2);
-  tc2->Dispose();
 
   // multiply second with c1g (create c1 and g)
   XPolynomial *pc1g = new XPolynomial();
-  XTerm *tc1g = g->Clone();
+  std::shared_ptr<XTerm> tc1g = std::dynamic_pointer_cast<XTerm>(g->Clone());
   std::shared_ptr<UPolynomialFraction> c1Clone = c1f1->GetUFraction()->Clone();
   tc1g->SetUFraction(c1Clone);
   pc1g->AddTerm(tc1g);
-  tc1g->Dispose();
   XPolynomial *xp2Clone = xp2->Clone();
   xp2Clone->Mul(pc1g);
   pc1g->Dispose();
@@ -514,7 +510,6 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   // subtract
   xp1->Subtract(xp2Clone);
   xp2Clone->Dispose();
-  g->Dispose();
 
   _maxt = std::max(_maxt, xp1->GetTotalTermCount());
 
@@ -626,10 +621,9 @@ bool Groebner::GCDCondition(XPolynomial *xp1, XPolynomial *xp2) {
   XTerm *m2 = (XTerm *)xp2->GetTerm(0);
 
   if (m1 && m2) {
-    m1 = m1->Clone();
-    m1->GCDWith(m2);
-    cond = (m1->GetPowerCount() == 0);
-    m1->Dispose();
+    std::shared_ptr<Term> m1s = m1->Clone();
+    m1s->GCDWith(m2);
+    cond = (m1s->GetPowerCount() == 0);
   }
 
   return cond;

--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -27,9 +27,8 @@ XPolynomial *PolyReader::_ReadXPolynomial(char *stream, int start, int end) {
       _Assert(e1 >= 0, "Right bracket missing!");
 
       // create XTerm and add it to the xpol
-      XTerm *xt = _ReadXTerm(stream, s1, e1);
+      std::shared_ptr<XTerm> xt = _ReadXTerm(stream, s1, e1);
       xpol->AddTerm(xt);
-      xt->Dispose();
     }
   } while (s1 > 0);
 
@@ -45,8 +44,8 @@ XPolynomial *PolyReader::_ReadXPolynomial(char *stream, int start, int end) {
 // Alternatively, it could start with a real coefficient
 // {C, XM1, XM2, ...} : type2
 //
-XTerm *PolyReader::_ReadXTerm(char *stream, int s, int e) {
-  XTerm *xt = new XTerm();
+std::shared_ptr<XTerm> PolyReader::_ReadXTerm(char *stream, int s, int e) {
+  std::shared_ptr<XTerm> xt = std::make_shared<XTerm>();
 
 #if DESER_DBG
   // debug
@@ -164,9 +163,8 @@ UPolynomial *PolyReader::_ReadUPolynomial(char *stream, int s, int e) {
       _Assert(e1 >= 0, "Right bracket missing!");
 
       // create UTerm and add it to the xpol
-      UTerm *ut = _ReadUTerm(stream, s1, e1);
+      std::shared_ptr<UTerm> ut = _ReadUTerm(stream, s1, e1);
       upol->AddTerm(ut);
-      ut->Dispose();
     }
   } while (s1 > 0);
 
@@ -177,14 +175,14 @@ UPolynomial *PolyReader::_ReadUPolynomial(char *stream, int s, int e) {
 // UTerm is a structure where first item is a real coefficient
 // and then there is a list of Powers
 //
-UTerm *PolyReader::_ReadUTerm(char *stream, int s, int e) {
+std::shared_ptr<UTerm> PolyReader::_ReadUTerm(char *stream, int s, int e) {
 #if DESER_DBG
   // debug
   Log::PrintLogF(0, "ut: ");
   _Print(stream, s, e);
 #endif
 
-  UTerm *ut = new UTerm();
+  std::shared_ptr<UTerm> ut = std::make_shared<UTerm>();
 
   // read real coefficient
   int s1 = s + 1, e1;

--- a/source/AlgebraicMethods/PolyReader.h
+++ b/source/AlgebraicMethods/PolyReader.h
@@ -18,10 +18,10 @@ private:
     static void _Assert(bool assert, const char* msg);
 
 	static XPolynomial* _ReadXPolynomial(char* stream, int start, int end);
-	static XTerm* _ReadXTerm(char* stream, int s, int e);
+	static std::shared_ptr<XTerm> _ReadXTerm(char* stream, int s, int e);
 	static std::shared_ptr<UPolynomialFraction> _ReadUFraction(char* stream, int s, int e);
 	static UPolynomial* _ReadUPolynomial(char* stream, int s, int e);
-	static UTerm* _ReadUTerm(char* stream, int s, int e);
+	static std::shared_ptr<UTerm> _ReadUTerm(char* stream, int s, int e);
 	static std::shared_ptr<Power> _ReadUPower(char* stream, int s, int e);
 	static std::shared_ptr<Power> _ReadXPower(char* stream, int s, int e);
 

--- a/source/AlgebraicMethods/Polynomial.cpp
+++ b/source/AlgebraicMethods/Polynomial.cpp
@@ -31,7 +31,7 @@ bool Polynomial::IsZero() const
 // add at the end
 // deserialization method
 //
-int Polynomial::AddTerm(Term* t)
+int Polynomial::AddTerm(std::shared_ptr<Term> t)
 {
 	if (t->Type() != this->Type())
 	{
@@ -47,7 +47,6 @@ int Polynomial::AddTerm(Term* t)
 void Polynomial::RemoveTerm(Term* t)
 {
 	_terms->RemoveTerm(t);
-	t->Dispose();
 }
 
 // aritmetic operations
@@ -81,11 +80,10 @@ int Polynomial::Mul(Polynomial* p)
 		uint cnt2 = p->GetTermCount();
 		for (uint jj = 0; jj < cnt2 && status == 0; jj++)
 		{
-			Term* t2clone = p->GetTerm(jj)->Clone();
+			std::shared_ptr<Term> t2clone = p->GetTerm(jj)->Clone();
 
 			t2clone->Mul(t1);
 			status = tmpTerms->AddTerm(t2clone);
-			t2clone->Dispose();
 		}
 	}
 
@@ -148,9 +146,8 @@ int Polynomial::Add(Polynomial* p)
 
 	for (uint ii = 0; ii < count && status == 0; ii ++)
 	{
-		Term* t = p->GetTerm(ii)->Clone();
+		std::shared_ptr<Term> t = p->GetTerm(ii)->Clone();
 		status = this->AddTerm(t);
-		t->Dispose();
 	}
 
 	return status;

--- a/source/AlgebraicMethods/Polynomial.h
+++ b/source/AlgebraicMethods/Polynomial.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Object.h"
 #include "Term.h"
 #include "TermStorage.h"
 #include "ITimeout.h"

--- a/source/AlgebraicMethods/Polynomial.h
+++ b/source/AlgebraicMethods/Polynomial.h
@@ -39,7 +39,7 @@ public:
 	uint GetTermCount() const;
 	Term* GetTerm(uint index) const;
 
-	int AddTerm(Term* t);
+	int AddTerm(std::shared_ptr<Term> t);
 	void RemoveTerm(Term* t);
 
 	// aritmetic operations

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Object.h"
 #include "Power.h"
 #include <iostream>
 #include <memory>
@@ -24,7 +23,7 @@ enum TERM_TYPE
 	XTERM
 };
 
-class Term : public Object
+class Term
 {
 protected:
 	// list of powers
@@ -37,7 +36,7 @@ public:
 	// comparison of two terms
 	virtual int Compare(Term* other) const;
 
-	virtual Term* Clone() = 0;
+	virtual std::shared_ptr<Term> Clone() = 0;
 
 	virtual TERM_TYPE Type() const = 0;
 

--- a/source/AlgebraicMethods/TermStorage.h
+++ b/source/AlgebraicMethods/TermStorage.h
@@ -2,6 +2,7 @@
 
 #include "Term.h"
 #include "ITimeout.h"
+#include <memory>
 
 //
 // Abstract terms container class
@@ -14,7 +15,7 @@ class TermStorage
 {
 public:
 
-	virtual int AddTerm(Term* term) = 0;
+	virtual int AddTerm(std::shared_ptr<Term> term) = 0;
 	virtual void RemoveTerm(Term* term) = 0;
 	virtual uint Count() const = 0;
 

--- a/source/AlgebraicMethods/TermStorageAvl.cpp
+++ b/source/AlgebraicMethods/TermStorageAvl.cpp
@@ -26,7 +26,7 @@ RIGHT_IMBALANCE(short bal) {
 
 // ----------------------------------------------- Constructors and Destructors
 
-AvlNode::AvlNode(Term* item)
+AvlNode::AvlNode(std::shared_ptr<Term> item)
    : myData(item), myBal(0)
 {
    Reset();
@@ -34,7 +34,7 @@ AvlNode::AvlNode(Term* item)
    COSTR("avl node");
 }
 
-void AvlNode::Construct(Term* item)
+void AvlNode::Construct(std::shared_ptr<Term> item)
 {
 	myData = item;
 	myBal = 0;
@@ -45,12 +45,6 @@ void AvlNode::Construct(Term* item)
 
 AvlNode::~AvlNode(void) 
 {
-	if (myData)
-	{
-		myData->Dispose();
-		myData = NULL;
-	}
-
 	DESTR("avl node");
 }
 
@@ -163,24 +157,22 @@ AvlNode::Compare(TermKeyType key, cmp_t cmp) const
 
 // ------------------------------------------------------- Insert/Delete
 
-Term*
-AvlNode::Insert(Term *item, std::shared_ptr<AvlNode> &root)
+std::shared_ptr<Term>
+AvlNode::Insert(std::shared_ptr<Term> item, std::shared_ptr<AvlNode> &root)
 {
    int  change;
    return  Insert(item, root, change);
 }
 
-
-Term*
+std::shared_ptr<Term>
 AvlNode::Delete(TermKeyType key, std::shared_ptr<AvlNode> &root, cmp_t cmp)
 {
    int  change;
    return  Delete(key, root, change, cmp);
 }
 
-
-Term*
-AvlNode::Insert(Term*   item,
+std::shared_ptr<Term>
+AvlNode::Insert(std::shared_ptr<Term> item,
 				std::shared_ptr<AvlNode> &root,
 				int& change)
 {
@@ -196,7 +188,7 @@ AvlNode::Insert(Term*   item,
    }
 
    // Initialize
-   Term* found = NULL;
+   std::shared_ptr<Term> found = NULL;
    int  increase = 0;
 
    // Compare items and determine which direction to search
@@ -213,9 +205,8 @@ AvlNode::Insert(Term*   item,
    else
    {   
 	   // merge terms
-	   root->myData->Merge(item);
+	   root->myData->Merge(item.get());
 	   ITimeout::CheckTimeout(); // in a case of exception, item is disposed later
-	   item->Dispose();
 
 	   // key already in tree at this node
 	   increase = HEIGHT_NOCHANGE;
@@ -235,9 +226,7 @@ AvlNode::Insert(Term*   item,
    return  NULL;
 }
 
-
-
-Term*
+std::shared_ptr<Term>
 AvlNode::Delete(TermKeyType              key,
                          std::shared_ptr<AvlNode> &root,
                          int                & change,
@@ -251,7 +240,7 @@ AvlNode::Delete(TermKeyType              key,
    }
 
       // Initialize
-   Term* found = NULL;
+   std::shared_ptr<Term> found = NULL;
    int  decrease = 0;
 
       // Compare items and determine which direction to search
@@ -265,7 +254,6 @@ AvlNode::Delete(TermKeyType              key,
       decrease = result * change;    // set balance factor decrement
    } else  {   // Found key at this node
       found = root->myData;  // set return value
-	  found->AddRef();
       // ----------------------------------------------------------------------------------
       // At this point we know "result" is zero and "root" points to
       // the node that we need to delete.  There are three cases:
@@ -297,11 +285,6 @@ AvlNode::Delete(TermKeyType              key,
       } else {
             // We have two children -- find successor and replace our current
             // data item with that of the successor
-
-		  // not disposing this term is a huge memory leak
-		  // strange thing is that program runs twice as fast
-		  // when term is not dispose!?
-		  root->myData->Dispose();
 
 		  root->myData = Delete(key, root->mySubtree[RIGHT],
 			  decrease, MIN_CMP);
@@ -397,22 +380,19 @@ void TermStorageAvlTree::Construct()
 	COSTR("reused avl tree");
 }
 
-int TermStorageAvlTree::AddTerm(Term* term)
+int TermStorageAvlTree::AddTerm(std::shared_ptr<Term> term)
 {
-	term->AddRef();
 	try
 	{
-		Term* t = Insert(term);
+		std::shared_ptr<Term> t = Insert(term);
 
 		if (t && t->IsZero())
 		{
-			Delete(t, EQ_CMP);
-			t->Dispose();
+			Delete(t.get(), EQ_CMP);
 		}
 	}
 	catch (int e)
 	{
-		term->Dispose();
 		return e;
 	}
 
@@ -488,7 +468,7 @@ Term* AvlNode::GetTerm(uint index) const
 
 	if (index == 0)
 	{
-		return this->Data();
+		return this->Data().get();
 	}
 
 	if (this->Subtree(RIGHT))

--- a/source/AlgebraicMethods/TermStorageAvl.cpp
+++ b/source/AlgebraicMethods/TermStorageAvl.cpp
@@ -161,19 +161,7 @@ AvlNode::Compare(TermKeyType key, cmp_t cmp) const
    }
 }
 
-// ------------------------------------------------------- Search/Insert/Delete
-
-
-Term*
-AvlNode::Search(TermKeyType key, AvlNode * root, cmp_t cmp)
-{
-   cmp_t result;
-   while (root  &&  (result = root->Compare(key, cmp))) {
-      root = root->mySubtree[(result < 0) ? LEFT : RIGHT].get();
-   }
-   return  (root) ? root->myData : NULL;
-}
-
+// ------------------------------------------------------- Insert/Delete
 
 Term*
 AvlNode::Insert(Term *item, std::shared_ptr<AvlNode> &root)

--- a/source/AlgebraicMethods/TermStorageAvl.h
+++ b/source/AlgebraicMethods/TermStorageAvl.h
@@ -63,7 +63,7 @@ public:
    AvlNode *
    Subtree(dir_t dir) const { return  mySubtree[dir].get(); }
 
-   // ----- Search/Insert/Delete
+   // ----- Insert/Delete
    //
    //   NOTE: These are all static functions instead of member functions
    //         because most of them need to modify the given tree root
@@ -73,11 +73,6 @@ public:
    //         functions that are static and which take an AVL tree
    //         pointer as a parameter are static for this reason.
    
-   // Look for the given key, return NULL if not found,
-   // otherwise return the item's address.
-   static Term*
-   Search(TermKeyType key, AvlNode * root, cmp_t cmp=EQ_CMP);
-
    // Insert the given key, return NULL if it was inserted,
    // otherwise return the existing item with the same key.
    static Term*
@@ -209,12 +204,7 @@ public:
       return  (myRoot == NULL);
    }
 
-   // Search, Insert, Delete, and Check
-   Term*
-   Search(TermKeyType key, cmp_t cmp=EQ_CMP) {
-      return  AvlNode::Search(key, myRoot.get(), cmp);
-   }
-
+   // Insert, Delete, and Check
    Term*
    Insert(Term* item) {
       return  AvlNode::Insert(item, myRoot);

--- a/source/AlgebraicMethods/TermStorageAvl.h
+++ b/source/AlgebraicMethods/TermStorageAvl.h
@@ -197,7 +197,7 @@ public:
    {
 	   COSTR("avl tree");
    };
-   ~TermStorageAvlTree() 
+   virtual ~TermStorageAvlTree()
    { 
 	   DESTR("avl tree");
    }

--- a/source/AlgebraicMethods/TermStorageAvl.h
+++ b/source/AlgebraicMethods/TermStorageAvl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Log.h"
 #include "TermStorage.h"
 #include <memory>
 

--- a/source/AlgebraicMethods/TermStorageAvl.h
+++ b/source/AlgebraicMethods/TermStorageAvl.h
@@ -36,14 +36,14 @@ public:
 
    // ----- Constructors and destructors: 
 
-   AvlNode(Term* item=NULL);
-   void Construct(Term* item=NULL);
+   AvlNode(std::shared_ptr<Term> item=NULL);
+   void Construct(std::shared_ptr<Term> item=NULL);
    ~AvlNode(void);
 
    // ----- Query attributes:
 
    // Get this node's data
-   Term*
+   std::shared_ptr<Term>
    Data() const { return  myData; }
 
    // Get this node's key field
@@ -76,12 +76,12 @@ public:
    
    // Insert the given key, return NULL if it was inserted,
    // otherwise return the existing item with the same key.
-   static Term*
-   Insert(Term* item, std::shared_ptr<AvlNode> &root);
+   static std::shared_ptr<Term>
+   Insert(std::shared_ptr<Term> item, std::shared_ptr<AvlNode> &root);
 
    // Delete the given key from the tree. Return the corresponding
    // node, or return NULL if it was not found.
-   static Term*
+   static std::shared_ptr<Term>
    Delete(TermKeyType key, std::shared_ptr<AvlNode> &root, cmp_t cmp=EQ_CMP);
 
    // Verification 
@@ -103,7 +103,7 @@ private:
 
    // ----- Private data
 
-   Term* myData;  // Data field
+   std::shared_ptr<Term> myData;  // Data field
    std::shared_ptr<AvlNode> mySubtree[MAX_SUBTREES];   // Pointers to subtrees
    short      myBal;   // Balance factor
 
@@ -121,15 +121,15 @@ private:
    // the key was successfully inserted.  Upon return, the "change"
    // parameter will be '1' if the tree height changed as a result
    // of the insertion (otherwise "change" will be 0).
-   static Term*
-   Insert(Term *item, std::shared_ptr<AvlNode> &root, int &change);
+   static std::shared_ptr<Term>
+   Insert(std::shared_ptr<Term> item, std::shared_ptr<AvlNode> &root, int &change);
 
    // Delete the given key from the given tree. Return NULL if the
    // key is not found in the tree. Otherwise return a pointer to the
    // node that was removed from the tree.  Upon return, the "change"
    // parameter will be '1' if the tree height changed as a result
    // of the deletion (otherwise "change" will be 0).
-   static Term*
+   static std::shared_ptr<Term>
    Delete(TermKeyType key,
              std::shared_ptr<AvlNode> &root,
              int & change,
@@ -206,12 +206,12 @@ public:
    }
 
    // Insert, Delete, and Check
-   Term*
-   Insert(Term* item) {
+   std::shared_ptr<Term>
+   Insert(std::shared_ptr<Term> item) {
       return  AvlNode::Insert(item, myRoot);
    }
 
-   Term*
+   std::shared_ptr<Term>
    Delete(TermKeyType key, cmp_t cmp=EQ_CMP) {
       return  AvlNode::Delete(key, myRoot, cmp);
    }
@@ -222,7 +222,7 @@ public:
    }
 
    // interface methods
-   int AddTerm(Term* term);
+   int AddTerm(std::shared_ptr<Term> term);
    void RemoveTerm(Term* term);
    uint Count() const;
 

--- a/source/AlgebraicMethods/TermStorageVector.cpp
+++ b/source/AlgebraicMethods/TermStorageVector.cpp
@@ -1,22 +1,13 @@
 #include "Log.h"
 #include "TermStorageVector.h"
+#include <memory>
 
 TermStorageVector::TermStorageVector()
 {
 }
 
-TermStorageVector::~TermStorageVector()
+int TermStorageVector::AddTerm(std::shared_ptr<Term> term)
 {
-	uint size = (uint)_terms.size();
-	for (uint ii = 0; ii < size; ii++)
-	{
-		_terms[ii]->Dispose();
-	}
-}
-
-int TermStorageVector::AddTerm(Term* term)
-{
-	term->AddRef();
 	_terms.push_back(term);
 	return 0;
 }
@@ -34,7 +25,7 @@ Term* TermStorageVector::GetTerm(uint index) const
 		throw -1;
 	}
 
-	return _terms[index];
+	return _terms[index].get();
 }
 
 // enumeration
@@ -57,5 +48,5 @@ Term* TermStorageVector::EnumGetCurrent() const
 		throw -1;
 	}
 
-	return _terms[_enumIndex];
+	return _terms[_enumIndex].get();
 }

--- a/source/AlgebraicMethods/TermStorageVector.cpp
+++ b/source/AlgebraicMethods/TermStorageVector.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "TermStorageVector.h"
 
 TermStorageVector::TermStorageVector()

--- a/source/AlgebraicMethods/TermStorageVector.h
+++ b/source/AlgebraicMethods/TermStorageVector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "TermStorage.h"
+#include <memory>
 
 //
 // TermStorage class implemented as a vector
@@ -10,14 +11,14 @@
 class TermStorageVector : public TermStorage
 {
 private:
-	std::vector<Term*> _terms;
+	std::vector<std::shared_ptr<Term>> _terms;
 	int _enumIndex;
 
 public:
 	TermStorageVector();
-	virtual ~TermStorageVector();
+	virtual ~TermStorageVector() = default;
 
-	int AddTerm(Term* term);
+	int AddTerm(std::shared_ptr<Term> term);
 	uint Count() const;
 
 	Term* GetTerm(uint index) const;

--- a/source/AlgebraicMethods/TermStorageVector.h
+++ b/source/AlgebraicMethods/TermStorageVector.h
@@ -15,7 +15,7 @@ private:
 
 public:
 	TermStorageVector();
-	~TermStorageVector();
+	virtual ~TermStorageVector();
 
 	int AddTerm(Term* term);
 	uint Count() const;

--- a/source/AlgebraicMethods/UPolynomial.cpp
+++ b/source/AlgebraicMethods/UPolynomial.cpp
@@ -1,4 +1,5 @@
 #include "UPolynomial.h"
+#include <memory>
 
 UPolynomial::UPolynomial()
 {
@@ -15,9 +16,8 @@ UPolynomial::~UPolynomial()
 //
 UPolynomial::UPolynomial(REAL cf)
 {
-	UTerm* ut = new UTerm(cf);
+	std::shared_ptr<UTerm> ut = std::make_shared<UTerm>(cf);
 	this->AddTerm(ut);
-	ut->Dispose();
 
 	COSTR("upoly");
 }
@@ -30,9 +30,8 @@ UPolynomial* UPolynomial::Clone()
 	while (_terms->EnumMoveNext())
 	{
 		UTerm* ut = (UTerm*)_terms->EnumGetCurrent();
-		UTerm* utClone = ut->Clone();
+		std::shared_ptr<Term> utClone = ut->Clone();
 		upClone->AddTerm(utClone);
-		utClone->Dispose();
 	}
 
 	return upClone;

--- a/source/AlgebraicMethods/UPolynomialFraction.cpp
+++ b/source/AlgebraicMethods/UPolynomialFraction.cpp
@@ -132,7 +132,8 @@ void UPolynomialFraction::SimpleReduction()
 		return;
 	}
 
-	UTerm* gcd = (UTerm*)_num->GetTerm(0)->Clone();
+	std::shared_ptr<UTerm> gcd =
+	  std::dynamic_pointer_cast<UTerm>(_num->GetTerm(0)->Clone());
 	gcd->SetCoeff(1);
 
 	// gcd of all terms in numerator
@@ -157,18 +158,16 @@ void UPolynomialFraction::SimpleReduction()
 		ii = 0;
 		while (ii < s1)
 		{
-			_num->GetTerm(ii++)->Divide(gcd);
+			_num->GetTerm(ii++)->Divide(gcd.get());
 		}
 
 		// denominator
 		ii = 0;
 		while (ii < s2)
 		{
-			_den->GetTerm(ii++)->Divide(gcd);
+			_den->GetTerm(ii++)->Divide(gcd.get());
 		}
 	}
-
-	gcd->Dispose();
 }
 
 // printing

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -1,3 +1,4 @@
+#include "Object.h"
 #include "UTerm.h"
 #include <cstddef>
 #include <cstdio>

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -24,19 +24,9 @@ UTerm::~UTerm()
 	DESTR("uterm");
 }
 
-void UTerm::Dispose()
+std::shared_ptr<Term> UTerm::Clone()
 {
-	_refCount --;
-
-	if (_refCount == 0)
-	{
-		delete this;
-	}
-}
-
-UTerm* UTerm::Clone()
-{
-	UTerm* utClone = new UTerm(this->GetCoeff());
+	std::shared_ptr<UTerm> utClone = std::make_shared<UTerm>(this->GetCoeff());
 
 	uint count = this->GetPowerCount();
     for (unsigned int ii = 0; ii < count; ii++)

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -16,9 +16,7 @@ public:
 
 	~UTerm();
 
-	void Dispose() override;
-
-	UTerm* Clone() override;
+	std::shared_ptr<Term> Clone() override;
 
 	TERM_TYPE Type() const override;
 

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -14,9 +14,9 @@ XTerm::~XTerm()
 	DESTR("xterm");
 }
 
-XTerm* XTerm::Clone()
+std::shared_ptr<Term> XTerm::Clone()
 {
-	XTerm* xtClone = new XTerm();
+	std::shared_ptr<XTerm> xtClone = std::make_shared<XTerm>();
 
 	// fraction
 	std::shared_ptr<UPolynomialFraction> ufClone = _frac->Clone();
@@ -32,9 +32,9 @@ XTerm* XTerm::Clone()
 	return xtClone;
 }
 
-XTerm* XTerm::ClonePowers()
+std::shared_ptr<XTerm> XTerm::ClonePowers()
 {
-	XTerm* xtClone = new XTerm();
+	std::shared_ptr<XTerm> xtClone = std::make_shared<XTerm>();
 
 	// powers
 	for (uint ii = 0; ii < this->GetPowerCount(); ii++)
@@ -54,8 +54,10 @@ TERM_TYPE XTerm::Type() const
 //
 // return p1p2
 //
-XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint index2)
-{
+std::shared_ptr<XTerm> XTerm::CreatePolynomialConditionTerm(bool f1,
+                                                            uint index1,
+                                                            bool f2,
+                                                            uint index2) {
 	if ((f1 && index1 == 0) || (f2 && index2 == 0))
 	{
 		return NULL;
@@ -66,7 +68,7 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 		return CreatePolynomialConditionTerm(f2, index2, f1, index1);
 	}
 
-	XTerm* xt = new XTerm();
+	std::shared_ptr<XTerm> xt = std::make_shared<XTerm>();
 
 	std::shared_ptr<UPolynomialFraction> upf;
 	if (f1 || f2)
@@ -98,10 +100,9 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 	}
 	else
 	{
-		UTerm* ut = new UTerm();
+		std::shared_ptr<UTerm> ut = std::make_shared<UTerm>();
 		ut->AddPower(p1);
 		xt->GetUFraction()->GetNumerator()->AddTerm(ut);
-		ut->Dispose();
 	}
 	if (!f2)
 	{
@@ -132,10 +133,9 @@ XTerm* XTerm::CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint 
 		else
 		{
 			// add term
-			UTerm* ut = new UTerm();
+			std::shared_ptr<UTerm> ut = std::make_shared<UTerm>();
 			ut->AddPower(p2);
 			xt->GetUFraction()->GetNumerator()->AddTerm(ut);
-			ut->Dispose();
 		}
 	}
 

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -15,12 +15,15 @@ public:
 	XTerm();
 	~XTerm();
 
-	XTerm* Clone() override;
-	XTerm* ClonePowers();
+	std::shared_ptr<Term> Clone() override;
+	std::shared_ptr<XTerm> ClonePowers();
 
 	TERM_TYPE Type() const override;
 
-	static XTerm* CreatePolynomialConditionTerm(bool f1, uint index1, bool f2, uint index2);
+	static std::shared_ptr<XTerm> CreatePolynomialConditionTerm(bool f1,
+	                                                            uint index1,
+	                                                            bool f2,
+	                                                            uint index2);
 
 	UPolynomialFraction* GetUFraction() const;
 	void SetUFraction(std::shared_ptr<UPolynomialFraction> uf);


### PR DESCRIPTION
This avoids the need for manual `Dispose` calls, removing an opportunity for accidental omissions. By leaning on the standard library, we also get a reference counting implementation optimised for the target platform.

A few things to note about this change:

1. This is significantly more complex and cross-cutting than the previous `std::shared_ptr` migrations. Unfortunately there seems to be no easy way to break this into smaller steps. We should put some consideration into whether this is definitely an improvement (and also whether it is correct).
2. There’s a bit of a foot gun wrt type safety that I’ve detailed in the final commit. I’m open to suggestions to improve/avoid this problem.
3. Some of the decisions here were a bit subjective. E.g. taking `shared_ptr`s in `Insert` to do the duplication when calling into these functions as opposed to specifically duplicating the `shared_ptr` later down the call chain.