### PR TITLE
fix infinite recursion in 'GraphNode::operator!=' 

### DIFF
--- a/source/GraphDrawing/graphnode.cpp
+++ b/source/GraphDrawing/graphnode.cpp
@@ -28,7 +28,7 @@ bool GraphNode::operator==(const GraphNode &newGraphNode) const {
 }
 
 bool GraphNode::operator!=(const GraphNode &newGraphNode) const {
-  return (*this != newGraphNode);
+  return !(*this == newGraphNode);
 }
 
 bool GraphNode::operator<(const GraphNode &newGraphNode) const {

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -2617,7 +2617,8 @@ bool CAlgMethod::_RationalizeConjecture(CGCLCProverExpression *conjecture) {
       // replace it with eNum
       CGCLCProverExpression *parent;
       int index;
-      bool b = exprToRationalize.GetParentIndex(*conjecture, parent, index);
+      [[maybe_unused]] bool b =
+        exprToRationalize.GetParentIndex(*conjecture, parent, index);
       assert(b);
       parent->SetArg(index, eNum);
 


### PR DESCRIPTION
The compiler notices:

```
  source/GraphDrawing/graphnode.cpp: In member function ‘bool GraphNode::operator!=(const GraphNode&) const’:
  source/GraphDrawing/graphnode.cpp:30:6: warning: infinite recursion detected [-Winfinite-recursion]
     30 | bool GraphNode::operator!=(const GraphNode &newGraphNode) const {
        |      ^~~~~~~~~
  source/GraphDrawing/graphnode.cpp:31:17: note: recursive call
     31 |   return (*this != newGraphNode);
        |          ~~~~~~~^~~~~~~~~~~~~~~~
```

Reported-by: GCC 13.3.0