### PR TITLE
regain covariance in '*Term::Clone()'

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -484,7 +484,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   }
 
   // divide f1/f2
-  std::shared_ptr<Term> g = c1f1->Clone();
+  std::shared_ptr<XTerm> g = c1f1->Clone();
   g->Divide(c2f2);
 
   // multiply first with c2 (must create c2 first)
@@ -496,7 +496,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
 
   // multiply second with c1g (create c1 and g)
   XPolynomial *pc1g = new XPolynomial();
-  std::shared_ptr<XTerm> tc1g = std::dynamic_pointer_cast<XTerm>(g->Clone());
+  std::shared_ptr<XTerm> tc1g = g->Clone();
   std::shared_ptr<UPolynomialFraction> c1Clone = c1f1->GetUFraction()->Clone();
   tc1g->SetUFraction(c1Clone);
   pc1g->AddTerm(tc1g);

--- a/source/AlgebraicMethods/Term.cpp
+++ b/source/AlgebraicMethods/Term.cpp
@@ -39,6 +39,10 @@ Term::~Term() {
 //
 int Term::Compare(Term * /* other */) const { return -1; }
 
+std::shared_ptr<Term> Term::Clone() {
+  return std::shared_ptr<Term>(Clone_impl());
+}
+
 //
 // Merge two equal terms
 //

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -36,7 +36,7 @@ public:
 	// comparison of two terms
 	virtual int Compare(Term* other) const;
 
-	virtual std::shared_ptr<Term> Clone() = 0;
+	std::shared_ptr<Term> Clone();
 
 	virtual TERM_TYPE Type() const = 0;
 
@@ -74,4 +74,7 @@ public:
 
 	virtual void PrettyPrint() const = 0;
 	virtual void PrintLatex(std::ostream &os) const = 0;
+
+private:
+	virtual Term *Clone_impl() = 0;
 };

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -24,9 +24,15 @@ UTerm::~UTerm()
 	DESTR("uterm");
 }
 
-std::shared_ptr<Term> UTerm::Clone()
+std::shared_ptr<UTerm> UTerm::Clone()
 {
-	std::shared_ptr<UTerm> utClone = std::make_shared<UTerm>(this->GetCoeff());
+	return std::shared_ptr<UTerm>(Clone_impl());
+}
+
+UTerm *UTerm::Clone_impl()
+{
+	std::unique_ptr<UTerm> utClone =
+	  std::unique_ptr<UTerm>(new UTerm(this->GetCoeff()));
 
 	uint count = this->GetPowerCount();
     for (unsigned int ii = 0; ii < count; ii++)
@@ -35,7 +41,7 @@ std::shared_ptr<Term> UTerm::Clone()
 		utClone->AddPower(uwClone);
 	}
 
-	return utClone;
+	return utClone.release();
 }
 
 TERM_TYPE UTerm::Type() const

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -16,7 +16,7 @@ public:
 
 	~UTerm();
 
-	std::shared_ptr<Term> Clone() override;
+	std::shared_ptr<UTerm> Clone();
 
 	TERM_TYPE Type() const override;
 
@@ -41,4 +41,7 @@ public:
 	// overriden methods
 	int Compare(Term* other) const override;
 	void Merge(Term* t) override;
+
+private:
+	UTerm *Clone_impl() override;
 };

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -14,9 +14,14 @@ XTerm::~XTerm()
 	DESTR("xterm");
 }
 
-std::shared_ptr<Term> XTerm::Clone()
+std::shared_ptr<XTerm> XTerm::Clone()
 {
-	std::shared_ptr<XTerm> xtClone = std::make_shared<XTerm>();
+	return std::shared_ptr<XTerm>(Clone_impl());
+}
+
+XTerm *XTerm::Clone_impl()
+{
+	std::unique_ptr<XTerm> xtClone = std::unique_ptr<XTerm>(new XTerm);
 
 	// fraction
 	std::shared_ptr<UPolynomialFraction> ufClone = _frac->Clone();
@@ -29,7 +34,7 @@ std::shared_ptr<Term> XTerm::Clone()
 		xtClone->AddPower(xwClone);
 	}
 
-	return xtClone;
+	return xtClone.release();
 }
 
 std::shared_ptr<XTerm> XTerm::ClonePowers()

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -15,7 +15,7 @@ public:
 	XTerm();
 	~XTerm();
 
-	std::shared_ptr<Term> Clone() override;
+	std::shared_ptr<XTerm> Clone();
 	std::shared_ptr<XTerm> ClonePowers();
 
 	TERM_TYPE Type() const override;
@@ -44,4 +44,7 @@ public:
 	// overriden methods
 	int Compare(Term* t) const override;
 	void Merge(Term* t) override;
+
+private:
+	XTerm *Clone_impl() override;
 };

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -103,7 +103,7 @@ XPolynomial *XPolynomial::Clone() {
 
   _terms->EnumReset();
   while (_terms->EnumMoveNext()) {
-    std::shared_ptr<Term> xtClone = ((XTerm *)_terms->EnumGetCurrent())->Clone();
+    std::shared_ptr<XTerm> xtClone = ((XTerm *)_terms->EnumGetCurrent())->Clone();
     xpClone->AddTerm(xtClone);
   }
 
@@ -152,13 +152,13 @@ void XPolynomial::SPol(XPolynomial *xp) {
   lt2 = (XTerm *)xp->GetTerm(0);
 
   // s1 * c2
-  std::shared_ptr<XTerm> s1c2 = std::dynamic_pointer_cast<XTerm>(lt2->Clone());
+  std::shared_ptr<XTerm> s1c2 = lt2->Clone();
   // s1c2->SetUFraction(lt2->GetUFraction()->Clone());
   // safe division
   s1c2->DivideMonoms(lt1);
 
   // s2 * c1
-  std::shared_ptr<XTerm> s2c1 = std::dynamic_pointer_cast<XTerm>(lt1->Clone());
+  std::shared_ptr<XTerm> s2c1 = lt1->Clone();
   // s2c1->SetUFraction(lt1->GetUFraction()->Clone());
   // safe division
   s2c1->DivideMonoms(lt2);
@@ -171,7 +171,7 @@ void XPolynomial::SPol(XPolynomial *xp) {
   // c2 * s1 * f1
   uint size = this->GetTermCount();
   for (i = 1; i < size; i++) {
-    std::shared_ptr<Term> t = s1c2->Clone();
+    std::shared_ptr<XTerm> t = s1c2->Clone();
     t->Mul(this->GetTerm(i));
     tmpTerms->AddTerm(t);
   }
@@ -179,7 +179,7 @@ void XPolynomial::SPol(XPolynomial *xp) {
   // - c1 * s2 * f2
   size = xp->GetTermCount();
   for (i = 1; i < size; i++) {
-    std::shared_ptr<Term> t = s2c1->Clone();
+    std::shared_ptr<XTerm> t = s2c1->Clone();
     t->Mul(xp->GetTerm(i));
     tmpTerms->AddTerm(t);
   }
@@ -300,7 +300,7 @@ bool XPolynomial::_PseudoRemainder(XPolynomial *xp, int index, bool free,
         }
       } else {
         // remove degree
-        xtClone = std::dynamic_pointer_cast<XTerm>(xt->Clone());
+        xtClone = xt->Clone();
         xtClone->ChangePowerDegree(index, -deg);
       }
 
@@ -319,7 +319,7 @@ bool XPolynomial::_PseudoRemainder(XPolynomial *xp, int index, bool free,
       // add only terms where degree of variable index match it highest degree
       if (xt->VariableDeg(index, free) == varDeg2) {
         // remove degree
-        std::shared_ptr<Term> xtClone = xt->Clone();
+        std::shared_ptr<XTerm> xtClone = xt->Clone();
         xtClone->ChangePowerDegree(index, -deg);
 
         // add it to the polynomial


### PR DESCRIPTION
The commit message for a31a0a0cecbc07d2f90a70d43d4e0b5f98a6a568 discusses a weakness wherein some type safety checks that could previously happen at compile-time were degraded to happening at runtime. The present change uses [a technique](https://www.fluentcpp.com/2017/09/12/how-to-return-a-smart-pointer-and-use-covariance/) to regain these compile-time checks.

Prior to this change, it was possible to write code like the following:

```cpp
std::shared_ptr<XTerm> xterm = std::make_shared<XTerm>();
std::shared_ptr<UTerm> uterm = std::dynamic_pointer_cast<UTerm>(xterm->Clone());
```

This clones an `XTerm` into a `UTerm`, something that is disallowed. However this would only be discovered through the `dynamic_pointer_cast` returning `nullptr` at runtime. That is, it is not possible for the compiler to statically observe the type safety violation here.

Prior to a31a0a0cecbc07d2f90a70d43d4e0b5f98a6a568, it would not have been possible to write such code:

```cpp
XTerm *xterm = new XTerm();
UTerm *uterm = xterm->Clone(); // ← fails to compile
```

With the present change, we re-establish this property:

```cpp
std::shared_ptr<XTerm> xterm = std::make_shared<XTerm>();
std::shared_ptr<UTerm> uterm = xterm->Clone(); // ← fails to compile
```

This change does not go as far as using [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) to abbreviate the boiler plate, as discussed in the linked blog post. For a shallow type hierarchy like `Term`, the increased complexity for the reader of this code does not seem worth it.