### PR TITLE
squash an unused variable warning in release mode

### DIFF
--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -2619,6 +2619,8 @@ bool CAlgMethod::_RationalizeConjecture(CGCLCProverExpression *conjecture) {
       int index;
       bool b = exprToRationalize.GetParentIndex(*conjecture, parent, index);
       assert(b);
+      // squash -Wunused-variable warning in release mode
+      (void)b;
       parent->SetArg(index, eNum);
 
       // propagate eDen


### PR DESCRIPTION
This is an alternative to 5489c074ce18ef16a1fc266ed80f7d0d6fb79ca2 that retains C++11 compatibility. What do you think of this option instead of the one from https://github.com/janicicpredrag/gclc/pull/87?