### PR TITLE
some simplifications and minor #include fixes

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -1,4 +1,5 @@
 #include "Groebner.h"
+#include "Log.h"
 #include "PolyReader.h"
 #include <algorithm>
 #include <memory>

--- a/source/AlgebraicMethods/Object.cpp
+++ b/source/AlgebraicMethods/Object.cpp
@@ -38,32 +38,3 @@ void Object::SetObjectId(int objId)
 {
 	_objectId = objId;
 }
-
-//
-// print real number without trailing zeros
-//
-void Object::PrintREAL(REAL f)
-{
-	static char dst[37];
-	sprintf(dst, "%.20lf", f);
-
-	int len = 0;
-	while (dst[len])
-	{
-		len ++;
-	}
-	--len;
-
-	while (dst[len] == '0')
-	{
-		len --;
-	}
-
-	if (dst[len] == '.')
-	{
-		len --;
-	}
-	dst[len + 1] = 0;
-
-	Log::PrintLogF(0, "%s", dst);
-}

--- a/source/AlgebraicMethods/Object.h
+++ b/source/AlgebraicMethods/Object.h
@@ -29,6 +29,4 @@ public:
 
 	int GetObjectId() const;
 	void SetObjectId(int objId);
-
-	static void PrintREAL(REAL f);
 };

--- a/source/AlgebraicMethods/PolyReader.cpp
+++ b/source/AlgebraicMethods/PolyReader.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "PolyReader.h"
 #include <algorithm>
 #include <memory>

--- a/source/AlgebraicMethods/Polynomial.cpp
+++ b/source/AlgebraicMethods/Polynomial.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "Polynomial.h"
 #include <memory>
 

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "Reduce.h"
 #include "PolyReader.h"
 #include <algorithm>

--- a/source/AlgebraicMethods/Term.cpp
+++ b/source/AlgebraicMethods/Term.cpp
@@ -39,7 +39,7 @@ Term::~Term() {
 //
 int Term::Compare(Term * /* other */) const { return -1; }
 
-std::shared_ptr<Term> Term::Clone() {
+std::shared_ptr<Term> Term::Clone() const {
   return std::shared_ptr<Term>(Clone_impl());
 }
 

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -76,5 +76,5 @@ public:
 	virtual void PrintLatex(std::ostream &os) const = 0;
 
 private:
-	virtual Term *Clone_impl() = 0;
+	virtual Term *Clone_impl() const = 0;
 };

--- a/source/AlgebraicMethods/Term.h
+++ b/source/AlgebraicMethods/Term.h
@@ -36,7 +36,7 @@ public:
 	// comparison of two terms
 	virtual int Compare(Term* other) const;
 
-	std::shared_ptr<Term> Clone();
+	std::shared_ptr<Term> Clone() const;
 
 	virtual TERM_TYPE Type() const = 0;
 

--- a/source/AlgebraicMethods/UPolynomial.cpp
+++ b/source/AlgebraicMethods/UPolynomial.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "UPolynomial.h"
 #include <memory>
 

--- a/source/AlgebraicMethods/UPolynomialFraction.cpp
+++ b/source/AlgebraicMethods/UPolynomialFraction.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "UPolynomialFraction.h"
 #include <iostream>
 #include <memory>

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -1,4 +1,4 @@
-#include "Object.h"
+#include "Log.h"
 #include "UTerm.h"
 #include <cstddef>
 #include <cstdio>

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<UTerm> UTerm::Clone()
 	return std::shared_ptr<UTerm>(Clone_impl());
 }
 
-UTerm *UTerm::Clone_impl()
+UTerm *UTerm::Clone_impl() const
 {
 	std::unique_ptr<UTerm> utClone =
 	  std::unique_ptr<UTerm>(new UTerm(this->GetCoeff()));

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -122,11 +122,40 @@ int UTerm::Inverse()
 // printing
 
 //
+// print real number without trailing zeros
+//
+static void PrintREAL(REAL f)
+{
+	static char dst[37];
+	sprintf(dst, "%.20lf", f);
+
+	int len = 0;
+	while (dst[len])
+	{
+		len ++;
+	}
+	--len;
+
+	while (dst[len] == '0')
+	{
+		len --;
+	}
+
+	if (dst[len] == '.')
+	{
+		len --;
+	}
+	dst[len + 1] = 0;
+
+	Log::PrintLogF(0, "%s", dst);
+}
+
+//
 // {coeff, UP1, UP2, ...}
 void UTerm::PrettyPrint() const
 {
 	Log::PrintLogF(0, "{");
-	Object::PrintREAL(_coeff);
+	PrintREAL(_coeff);
 	Log::PrintLogF(0, ", ", _coeff);
 
 	uint size = this->GetPowerCount();

--- a/source/AlgebraicMethods/UTerm.cpp
+++ b/source/AlgebraicMethods/UTerm.cpp
@@ -24,7 +24,7 @@ UTerm::~UTerm()
 	DESTR("uterm");
 }
 
-std::shared_ptr<UTerm> UTerm::Clone()
+std::shared_ptr<UTerm> UTerm::Clone() const
 {
 	return std::shared_ptr<UTerm>(Clone_impl());
 }

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -16,7 +16,7 @@ public:
 
 	~UTerm();
 
-	std::shared_ptr<UTerm> Clone();
+	std::shared_ptr<UTerm> Clone() const;
 
 	TERM_TYPE Type() const override;
 

--- a/source/AlgebraicMethods/UTerm.h
+++ b/source/AlgebraicMethods/UTerm.h
@@ -43,5 +43,5 @@ public:
 	void Merge(Term* t) override;
 
 private:
-	UTerm *Clone_impl() override;
+	UTerm *Clone_impl() const override;
 };

--- a/source/AlgebraicMethods/Wu.cpp
+++ b/source/AlgebraicMethods/Wu.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "Wu.h"
 #include "PolyReader.h"
 #include "Reduce.h"

--- a/source/AlgebraicMethods/Wu.cpp
+++ b/source/AlgebraicMethods/Wu.cpp
@@ -2,6 +2,7 @@
 #include "PolyReader.h"
 #include "Reduce.h"
 #include <algorithm>
+#include <utility>
 
 const std::string Wu::Description() { return "Wu's method"; }
 
@@ -153,9 +154,7 @@ bool Wu::_Triangulate(vxp& vxps, vector<int>& vars)
 					// swap vxps[ii] and vxps[jj]
 					if (ii != jj)
 					{
-						XPolynomial* xp = vxps[ii];
-						vxps[ii] = vxps[jj];
-						vxps[jj] = xp;
+						std::swap(vxps[ii], vxps[jj]);
 					}
 					else
 					{

--- a/source/AlgebraicMethods/Wu.cpp
+++ b/source/AlgebraicMethods/Wu.cpp
@@ -214,9 +214,7 @@ bool Wu::_Triangulate(vxp& vxps, vector<int>& vars)
                 Log::PrintLogF(1, "\\item[Polynomial with linear degree:] Removing variable $x_{%d}$ from all other polynomials by reducing them with polynomial $p_{%d}$.\n\n", var, ii);
 
 				// move it to the next pos and reduce all remaining with it
-				XPolynomial* xp = vxps[ii];
-				vxps[ii] = vxps[pos1];
-				vxps[pos1] = xp;
+				std::swap(vxps[ii], vxps[pos1]);
 
 				for (jj = 0; jj < ii; jj++)
 				{

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "XTerm.h"
 #include "XPolynomial.h"
 #include "PolyReader.h"

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<XTerm> XTerm::Clone()
 	return std::shared_ptr<XTerm>(Clone_impl());
 }
 
-XTerm *XTerm::Clone_impl()
+XTerm *XTerm::Clone_impl() const
 {
 	std::unique_ptr<XTerm> xtClone = std::unique_ptr<XTerm>(new XTerm);
 

--- a/source/AlgebraicMethods/XTerm.cpp
+++ b/source/AlgebraicMethods/XTerm.cpp
@@ -14,7 +14,7 @@ XTerm::~XTerm()
 	DESTR("xterm");
 }
 
-std::shared_ptr<XTerm> XTerm::Clone()
+std::shared_ptr<XTerm> XTerm::Clone() const
 {
 	return std::shared_ptr<XTerm>(Clone_impl());
 }

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -46,5 +46,5 @@ public:
 	void Merge(Term* t) override;
 
 private:
-	XTerm *Clone_impl() override;
+	XTerm *Clone_impl() const override;
 };

--- a/source/AlgebraicMethods/XTerm.h
+++ b/source/AlgebraicMethods/XTerm.h
@@ -15,7 +15,7 @@ public:
 	XTerm();
 	~XTerm();
 
-	std::shared_ptr<XTerm> Clone();
+	std::shared_ptr<XTerm> Clone() const;
 	std::shared_ptr<XTerm> ClonePowers();
 
 	TERM_TYPE Type() const override;

--- a/source/AlgebraicMethods/xpolynomial.cpp
+++ b/source/AlgebraicMethods/xpolynomial.cpp
@@ -1,3 +1,4 @@
+#include "Log.h"
 #include "PolyReader.h"
 #include "XPolynomial.h"
 #include <iostream>

--- a/source/TheoremProver/AlgMethod.cpp
+++ b/source/TheoremProver/AlgMethod.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "AlgMethod.h"
+#include "../AlgebraicMethods/Log.h"
 #include "../AlgebraicMethods/PolyReader.h"
 #include <algorithm>
 #include <assert.h>

--- a/source/TheoremProver/AlgMethodReducible.cpp
+++ b/source/TheoremProver/AlgMethodReducible.cpp
@@ -4,6 +4,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "AlgMethod.h"
+#include "../AlgebraicMethods/Log.h"
 #include "../AlgebraicMethods/PolyReader.h"
 #include "../AlgebraicMethods/Reduce.h"
 


### PR DESCRIPTION
A few things I came across recently, that I tried to break up into fine-grained changes.

----

To foreshadow where this is going, this is the prefix of a series I have that replaces the reference counting of the `Polynomial` hierarchy with `std::shared_ptr` as was previously done with other types. There are a few things along the way I could use some guidance with:
1. Some of this upcoming series touches dead code. E.g. Much of the code in source/AlgebraicMethods/PolyReader.cpp is unused. My instinct would be to remove this instead of going through the work of porting it, but maybe there is a motivation to keep it?
2. Similarly there is quite a lot of commented out code that I’ve been updating in an attempt to keep it compilable should it be un-commented. Should we instead remove this? It will always be there in the Git log if we need to regain it.
3. The final commit that does the change itself has a nice effect (no more `Dispose` calls, `Object` is removed), but it is quite large (~1500 line diff). I haven’t come up with an easy way to shrink this because it includes things like `foo->Add(bar)` becoming `foo->Add(bar.get())`. We could add `std::shared_ptr<Polynomial>`-taking overloads to `Add`/etc to avoid this, but I’m not sure how others feel about this kind of overloading.