### PR TITLE
fix some 'XPolynomial' memory leaks

### DIFF
--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -489,11 +489,11 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   g->Divide(c2f2);
 
   // multiply first with c2 (must create c2 first)
-  XPolynomial *pc2 = new XPolynomial();
+  XPolynomial pc2;
   std::shared_ptr<XTerm> tc2 = std::make_shared<XTerm>();
   std::shared_ptr<UPolynomialFraction> c2Clone = c2f2->GetUFraction()->Clone();
   tc2->SetUFraction(c2Clone);
-  pc2->AddTerm(tc2);
+  pc2.AddTerm(tc2);
 
   // multiply second with c1g (create c1 and g)
   XPolynomial *pc1g = new XPolynomial();
@@ -505,8 +505,7 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   xp2Clone->Mul(pc1g);
   pc1g->Dispose();
 
-  xp1->Mul(pc2);
-  pc2->Dispose();
+  xp1->Mul(&pc2);
 
   // subtract
   xp1->Subtract(xp2Clone);

--- a/source/AlgebraicMethods/Groebner.cpp
+++ b/source/AlgebraicMethods/Groebner.cpp
@@ -496,14 +496,13 @@ bool Groebner::Reduce(XPolynomial *xp1, XPolynomial *xp2) {
   pc2.AddTerm(tc2);
 
   // multiply second with c1g (create c1 and g)
-  XPolynomial *pc1g = new XPolynomial();
+  XPolynomial pc1g;
   std::shared_ptr<XTerm> tc1g = g->Clone();
   std::shared_ptr<UPolynomialFraction> c1Clone = c1f1->GetUFraction()->Clone();
   tc1g->SetUFraction(c1Clone);
-  pc1g->AddTerm(tc1g);
+  pc1g.AddTerm(tc1g);
   XPolynomial *xp2Clone = xp2->Clone();
-  xp2Clone->Mul(pc1g);
-  pc1g->Dispose();
+  xp2Clone->Mul(&pc1g);
 
   xp1->Mul(&pc2);
 

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -21,9 +21,9 @@ bool Reduce::ReduceLineCircleIntersection(
     }
 #endif
 
-    XPolynomial *xp12, *xp21, *xp22;
+    XPolynomial *xp21, *xp22;
     XPolynomial xp11(vecPointsFree[0], vecPointsIndex[0]);
-    xp12 = new XPolynomial(vecPointsFree[1], vecPointsIndex[1]);
+    XPolynomial xp12(vecPointsFree[1], vecPointsIndex[1]);
     xp21 = new XPolynomial(vecPointsFree[2], vecPointsIndex[2]);
     xp22 = new XPolynomial(vecPointsFree[3], vecPointsIndex[3]);
 
@@ -35,7 +35,7 @@ bool Reduce::ReduceLineCircleIntersection(
     PolyReader::PrintPolynomials(polySystem, level);
     Log::PrintLogF(level, "First point:\n\n");
     PolyReader::PrintPolynomial(&xp11, level);
-    PolyReader::PrintPolynomial(xp12, level);
+    PolyReader::PrintPolynomial(&xp12, level);
     Log::PrintLogF(level, "Second point:\n\n");
     PolyReader::PrintPolynomial(xp21, level);
     PolyReader::PrintPolynomial(xp22, level);
@@ -100,7 +100,7 @@ bool Reduce::ReduceLineCircleIntersection(
 
     // pols 0, size - 3 are linear in x11 and x21
     Log::PrintLogF(level, "x12 = :\n\n");
-    PolyReader::PrintPolynomial(xp12, level);
+    PolyReader::PrintPolynomial(&xp12, level);
     Log::PrintLogF(level, "x22 = :\n\n");
     PolyReader::PrintPolynomial(xp22, level);
 
@@ -121,7 +121,7 @@ bool Reduce::ReduceLineCircleIntersection(
         Log::PrintLogF(level, "Reducing with pol %d\n\n", ii);
         PolyReader::PrintPolynomial(x, level);
 
-        if (!xp12->IsZero() && x->LeadTerm(vecPointsIndex[1], vecPointsFree[1]))
+        if (!xp12.IsZero() && x->LeadTerm(vecPointsIndex[1], vecPointsFree[1]))
         {
             Log::PrintLogF(level, "Reducing last pol with x12 (second point) index %d:\n\n", vecPointsIndex[1]);
             polySystem[size - 1]->PseudoRemainder(x, vecPointsIndex[1], vecPointsFree[1]);
@@ -195,7 +195,6 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "After reduction:\n\n");
     PolyReader::PrintPolynomials(polySystem, 1);
 
-    xp12->Dispose();
     xp21->Dispose();
     xp22->Dispose();
 

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -21,11 +21,10 @@ bool Reduce::ReduceLineCircleIntersection(
     }
 #endif
 
-    XPolynomial *xp22;
     XPolynomial xp11(vecPointsFree[0], vecPointsIndex[0]);
     XPolynomial xp12(vecPointsFree[1], vecPointsIndex[1]);
     XPolynomial xp21(vecPointsFree[2], vecPointsIndex[2]);
-    xp22 = new XPolynomial(vecPointsFree[3], vecPointsIndex[3]);
+    XPolynomial xp22(vecPointsFree[3], vecPointsIndex[3]);
 
     bool bRet = true;
 
@@ -38,7 +37,7 @@ bool Reduce::ReduceLineCircleIntersection(
     PolyReader::PrintPolynomial(&xp12, level);
     Log::PrintLogF(level, "Second point:\n\n");
     PolyReader::PrintPolynomial(&xp21, level);
-    PolyReader::PrintPolynomial(xp22, level);
+    PolyReader::PrintPolynomial(&xp22, level);
 
 #if 1
     Log::PrintLogF(level, "Reducing second with first in x6:\n\n");
@@ -102,7 +101,7 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "x12 = :\n\n");
     PolyReader::PrintPolynomial(&xp12, level);
     Log::PrintLogF(level, "x22 = :\n\n");
-    PolyReader::PrintPolynomial(xp22, level);
+    PolyReader::PrintPolynomial(&xp22, level);
 
     for (ii = 0; ii <= size - 3; ii++)
     {
@@ -131,7 +130,7 @@ bool Reduce::ReduceLineCircleIntersection(
             polySystem[size - 2]->PseudoRemainder(x, vecPointsIndex[1], vecPointsFree[1]);
             PolyReader::PrintPolynomial(polySystem[size - 2], level);
         }
-        if (!xp22->IsZero() && x->LeadTerm(vecPointsIndex[3], vecPointsFree[3]))
+        if (!xp22.IsZero() && x->LeadTerm(vecPointsIndex[3], vecPointsFree[3]))
         {
             Log::PrintLogF(level, "Reducing last pol with x2 (fourth point) index %d:\n\n", vecPointsIndex[3]);
             polySystem[size - 1]->PseudoRemainder(x, vecPointsIndex[3], vecPointsFree[3]);
@@ -194,8 +193,6 @@ bool Reduce::ReduceLineCircleIntersection(
     // exit info
     Log::PrintLogF(level, "After reduction:\n\n");
     PolyReader::PrintPolynomials(polySystem, 1);
-
-    xp22->Dispose();
 
     // clean exit
     //throw -1;

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -21,8 +21,8 @@ bool Reduce::ReduceLineCircleIntersection(
     }
 #endif
 
-    XPolynomial *xp11, *xp12, *xp21, *xp22;
-    xp11 = new XPolynomial(vecPointsFree[0], vecPointsIndex[0]);
+    XPolynomial *xp12, *xp21, *xp22;
+    XPolynomial xp11(vecPointsFree[0], vecPointsIndex[0]);
     xp12 = new XPolynomial(vecPointsFree[1], vecPointsIndex[1]);
     xp21 = new XPolynomial(vecPointsFree[2], vecPointsIndex[2]);
     xp22 = new XPolynomial(vecPointsFree[3], vecPointsIndex[3]);
@@ -34,7 +34,7 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "Reduce following polynomial system:\n\n");
     PolyReader::PrintPolynomials(polySystem, level);
     Log::PrintLogF(level, "First point:\n\n");
-    PolyReader::PrintPolynomial(xp11, level);
+    PolyReader::PrintPolynomial(&xp11, level);
     PolyReader::PrintPolynomial(xp12, level);
     Log::PrintLogF(level, "Second point:\n\n");
     PolyReader::PrintPolynomial(xp21, level);
@@ -49,10 +49,10 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "Subtracting last two pols:\n\n");
     PolyReader::PrintPolynomial(polySystem[2], level);
 
-    xp11->Subtract(xp21);
+    xp11.Subtract(xp21);
     Log::PrintLogF(level, "Divide third with x7 - x2:\n\n");
     XPolynomial* xd1 = new XPolynomial();
-    polySystem[2]->PseudoRemainder(xp11, 7, false, xd1);
+    polySystem[2]->PseudoRemainder(&xp11, 7, false, xd1);
     PolyReader::PrintPolynomial(polySystem[2], level);
     Log::PrintLogF(level, "Division remainder:\n\n");
     PolyReader::PrintPolynomial(polySystem[2], level);
@@ -163,7 +163,7 @@ bool Reduce::ReduceLineCircleIntersection(
     // (e5) last pol should have factor (x11 - x21)
     // (e6) divide with (x11 - x21)
     Log::PrintLogF(level, "dividing last pol with (x11 - x21) (first - third point):\n\n");
-    XPolynomial* xf = xp11->Clone();
+    XPolynomial* xf = xp11.Clone();
     xf->Subtract(xp21);
     Log::PrintLogF(level, "x11 - x21 = \n\n");
     PolyReader::PrintPolynomial(xf, level);
@@ -195,7 +195,6 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "After reduction:\n\n");
     PolyReader::PrintPolynomials(polySystem, 1);
 
-    xp11->Dispose();
     xp12->Dispose();
     xp21->Dispose();
     xp22->Dispose();

--- a/source/AlgebraicMethods/Reduce.cpp
+++ b/source/AlgebraicMethods/Reduce.cpp
@@ -21,10 +21,10 @@ bool Reduce::ReduceLineCircleIntersection(
     }
 #endif
 
-    XPolynomial *xp21, *xp22;
+    XPolynomial *xp22;
     XPolynomial xp11(vecPointsFree[0], vecPointsIndex[0]);
     XPolynomial xp12(vecPointsFree[1], vecPointsIndex[1]);
-    xp21 = new XPolynomial(vecPointsFree[2], vecPointsIndex[2]);
+    XPolynomial xp21(vecPointsFree[2], vecPointsIndex[2]);
     xp22 = new XPolynomial(vecPointsFree[3], vecPointsIndex[3]);
 
     bool bRet = true;
@@ -37,7 +37,7 @@ bool Reduce::ReduceLineCircleIntersection(
     PolyReader::PrintPolynomial(&xp11, level);
     PolyReader::PrintPolynomial(&xp12, level);
     Log::PrintLogF(level, "Second point:\n\n");
-    PolyReader::PrintPolynomial(xp21, level);
+    PolyReader::PrintPolynomial(&xp21, level);
     PolyReader::PrintPolynomial(xp22, level);
 
 #if 1
@@ -49,7 +49,7 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "Subtracting last two pols:\n\n");
     PolyReader::PrintPolynomial(polySystem[2], level);
 
-    xp11.Subtract(xp21);
+    xp11.Subtract(&xp21);
     Log::PrintLogF(level, "Divide third with x7 - x2:\n\n");
     XPolynomial* xd1 = new XPolynomial();
     polySystem[2]->PseudoRemainder(&xp11, 7, false, xd1);
@@ -164,7 +164,7 @@ bool Reduce::ReduceLineCircleIntersection(
     // (e6) divide with (x11 - x21)
     Log::PrintLogF(level, "dividing last pol with (x11 - x21) (first - third point):\n\n");
     XPolynomial* xf = xp11.Clone();
-    xf->Subtract(xp21);
+    xf->Subtract(&xp21);
     Log::PrintLogF(level, "x11 - x21 = \n\n");
     PolyReader::PrintPolynomial(xf, level);
 
@@ -195,7 +195,6 @@ bool Reduce::ReduceLineCircleIntersection(
     Log::PrintLogF(level, "After reduction:\n\n");
     PolyReader::PrintPolynomials(polySystem, 1);
 
-    xp21->Dispose();
     xp22->Dispose();
 
     // clean exit


### PR DESCRIPTION
The leaks fixed here are latent. As discussed in the commit messages:

> the initial `return false` ensures most of this function is never executed

Please let me know if you think we should handle this a different way, e.g. by removing this unreachable code.