### PR TITLE
Update to C++17 for clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,8 @@ add_executable(gclc
   source/Import/ListOfFaces.cpp 
 )
 
-# require ISO C++11
-target_compile_features(gclc PRIVATE cxx_std_11)
+# Update ISO to C++17
+target_compile_features(gclc PRIVATE cxx_std_17)
 
 install(TARGETS gclc
   RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
Good Day.
Building `gclc` with clang compiler on C++11 standard:
```
gclc git:(master) g++ --version
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
produces this build issue:
```
➜  gclc git:(master) cmake -B build -S .                            
CMake Warning at CMakeLists.txt:33 (find_package):
  By not providing "FindQt6.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt6", but
  CMake did not find one.

  Could not find a package configuration file provided by "Qt6" with any of
  the following names:

    Qt6Config.cmake
    qt6-config.cmake

  Add the installation prefix of "Qt6" to CMAKE_PREFIX_PATH or set "Qt6_DIR"
  to a directory containing one of the above files.  If "Qt6" provides a
  separate development package or SDK, be sure it has been installed.


-- setting -Dgui=OFF
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/danil-andreev/Projects/gclc/build
➜  gclc git:(master) cmake --build build --target install           
[  1%] Building CXX object CMakeFiles/gclc.dir/source/cGCLCmain.cpp.o
[  3%] Building CXX object CMakeFiles/gclc.dir/source/Export/TikZOutput.cpp.o
[  4%] Building CXX object CMakeFiles/gclc.dir/source/Export/SVGOutput.cpp.o
[  6%] Building CXX object CMakeFiles/gclc.dir/source/Export/PSTricksOutput.cpp.o
[  7%] Building CXX object CMakeFiles/gclc.dir/source/Export/LaTeXOutput.cpp.o
[  9%] Building CXX object CMakeFiles/gclc.dir/source/Export/GCLCOutput.cpp.o
[ 10%] Building CXX object CMakeFiles/gclc.dir/source/Export/EPSOutput.cpp.o
[ 12%] Building CXX object CMakeFiles/gclc.dir/source/ExpressionParser/parser.cpp.o
[ 13%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Transformations.cpp.o
[ 15%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/TheoremProving.cpp.o
[ 16%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/LowLevelCommands.cpp.o
[ 18%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Layers.cpp.o
[ 19%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/LabelingCommands.cpp.o
[ 21%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/GCLC.cpp.o
[ 22%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/DrawingCommands.cpp.o
[ 24%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Cartesian3DCommands.cpp.o
[ 25%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Cartesian2DCommands.cpp.o
[ 27%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Calculations.cpp.o
[ 28%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/BasicDefinitions.cpp.o
[ 30%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/BasicConstructions.cpp.o
[ 31%] Building CXX object CMakeFiles/gclc.dir/source/GCLCEngine/Animations.cpp.o
[ 33%] Building CXX object CMakeFiles/gclc.dir/source/GenericEngine/IntermediateRepresentation.cpp.o
[ 34%] Building CXX object CMakeFiles/gclc.dir/source/GenericEngine/GCompiler.cpp.o
[ 36%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/settings.cpp.o
[ 37%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/graph_util.cpp.o
[ 39%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/graphnode.cpp.o
[ 40%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/graph.cpp.o
[ 42%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/drawing.cpp.o
[ 43%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/barycenterdrawing.cpp.o
[ 45%] Building CXX object CMakeFiles/gclc.dir/source/GraphDrawing/arclayereddrawing.cpp.o
[ 46%] Building CXX object CMakeFiles/gclc.dir/source/Input/StringInput.cpp.o
[ 48%] Building CXX object CMakeFiles/gclc.dir/source/Input/GCLCInput.cpp.o
[ 50%] Building CXX object CMakeFiles/gclc.dir/source/Input/FileInput.cpp.o
[ 51%] Building CXX object CMakeFiles/gclc.dir/source/Logging/GCLCLog.cpp.o
[ 53%] Building CXX object CMakeFiles/gclc.dir/source/Logging/FileLog.cpp.o
[ 54%] Building CXX object CMakeFiles/gclc.dir/source/Logging/DummyLog.cpp.o
[ 56%] Building CXX object CMakeFiles/gclc.dir/source/Utils/Utils.cpp.o
/Users/danil-andreev/Projects/gclc/source/Utils/Utils.cpp:337:13: warning: explicitly assigning value of variable of type 'double' to itself [-Wself-assign]
  337 |         x2c = x2c;
      |         ~~~ ^ ~~~
/Users/danil-andreev/Projects/gclc/source/Utils/Utils.cpp:338:13: warning: explicitly assigning value of variable of type 'double' to itself [-Wself-assign]
  338 |         y2c = y2c;
      |         ~~~ ^ ~~~
/Users/danil-andreev/Projects/gclc/source/Utils/Utils.cpp:377:13: warning: explicitly assigning value of variable of type 'double' to itself [-Wself-assign]
  377 |         x2c = x2c;
      |         ~~~ ^ ~~~
/Users/danil-andreev/Projects/gclc/source/Utils/Utils.cpp:378:13: warning: explicitly assigning value of variable of type 'double' to itself [-Wself-assign]
  378 |         y2c = y2c;
      |         ~~~ ^ ~~~
4 warnings generated.
[ 57%] Building CXX object CMakeFiles/gclc.dir/source/Utils/Timer.cpp.o
[ 59%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/WuMethod.cpp.o
[ 60%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/TheoremProver.cpp.o
/Users/danil-andreev/Projects/gclc/source/TheoremProver/TheoremProver.cpp:1175:16: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
 1175 |         return NULL; // changed on 11.2015.
      |         ~~~~~~ ^~~~
      |                false
1 warning generated.
[ 62%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/ProverExpression.cpp.o
[ 63%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/GroebnerMethod.cpp.o
[ 65%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/AreaMethod.cpp.o
[ 66%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/AlgMethodReducible.cpp.o
[ 68%] Building CXX object CMakeFiles/gclc.dir/source/TheoremProver/AlgMethod.cpp.o
/Users/danil-andreev/Projects/gclc/source/TheoremProver/AlgMethod.cpp:463:7: warning: variable 'freeCount' set but not used [-Wunused-but-set-variable]
  463 |   int freeCount = 0;
      |       ^
1 warning generated.
[ 69%] Building CXX object CMakeFiles/gclc.dir/source/AlgebraicMethods/XTerm.cpp.o
[ 71%] Building CXX object CMakeFiles/gclc.dir/source/AlgebraicMethods/xpolynomial.cpp.o
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/xpolynomial.cpp:411:15: error: cannot initialize a parameter of type 'char *' with an rvalue of type 'const value_type *' (aka 'const char *')
  411 |   _ResReplace(str.data(), '+', '-', '-', false);
      |               ^~~~~~~~~~
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/XPolynomial.h:10:25: note: passing argument to parameter 'res' here
   10 |         void _ResReplace(char* res, char l1, char l2, char r1, bool nnCond) const;
      |                                ^
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/xpolynomial.cpp:412:15: error: cannot initialize a parameter of type 'char *' with an rvalue of type 'const value_type *' (aka 'const char *')
  412 |   _ResReplace(str.data(), '-', '+', '-', false);
      |               ^~~~~~~~~~
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/XPolynomial.h:10:25: note: passing argument to parameter 'res' here
   10 |         void _ResReplace(char* res, char l1, char l2, char r1, bool nnCond) const;
      |                                ^
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/xpolynomial.cpp:417:15: error: cannot initialize a parameter of type 'char *' with an rvalue of type 'const value_type *' (aka 'const char *')
  417 |   _ResReplace(str.data(), '1', 'x', 'x', true);
      |               ^~~~~~~~~~
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/XPolynomial.h:10:25: note: passing argument to parameter 'res' here
   10 |         void _ResReplace(char* res, char l1, char l2, char r1, bool nnCond) const;
      |                                ^
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/xpolynomial.cpp:418:15: error: cannot initialize a parameter of type 'char *' with an rvalue of type 'const value_type *' (aka 'const char *')
  418 |   _ResReplace(str.data(), '1', 'u', 'u', true);
      |               ^~~~~~~~~~
/Users/danil-andreev/Projects/gclc/source/AlgebraicMethods/XPolynomial.h:10:25: note: passing argument to parameter 'res' here
   10 |         void _ResReplace(char* res, char l1, char l2, char r1, bool nnCond) const;
      |                                ^
4 errors generated.
make[2]: *** [CMakeFiles/gclc.dir/source/AlgebraicMethods/xpolynomial.cpp.o] Error 1
make[1]: *** [CMakeFiles/gclc.dir/all] Error 2
make: *** [all] Error 2
```

This happens because the working draft for C++11/C++14 (N3337) defines the string accessors as:
```
const charT* c_str() const noexcept;
const charT* data()  const noexcept;
```
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3337.pdf

and the C++17 working draft (N4659) adds a non-const overload;
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4659.pdf

But it is not clear for me, why your build on the linux machine with `g++` didn't fail...
Maybe because default C++ dialect for GCC 11 is gnu++17, not sure

Nevertheless, this PR with fix to `cxx_std_17 ` produces stable build on both platforms
Looking forward to your review